### PR TITLE
Fixing warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-GlobalFoundries 180um MCU 7 track standard cells libraries
+GlobalFoundries 180nm MCU 7 track standard cells libraries
 ==========================================================
 
 This repository contains the "7 track standard cells" implementation as part of

--- a/cells/addf/gf180mcu_fd_sc_mcu7t5v0__addf_1.rst
+++ b/cells/addf/gf180mcu_fd_sc_mcu7t5v0__addf_1.rst
@@ -68,7 +68,9 @@ CO             ((A&B)|(A&CI)|(B&CI))
 
 |
 | FUNCTIONAL SCHEMATIC
-| |Schematic Not Available|
+
+.. image:: gf180mcu_fd_sc_mcu7t5v0__addf_1.png
+
 | PIN CAPACITANCE (pf)
 
 ======= ======== ====================

--- a/docs/symbols.rst
+++ b/docs/symbols.rst
@@ -1,0 +1,20 @@
+=========================
+Reading Databook Symbols
+=========================
+
+========== ================================
+**Symbol** **Definition**
+0          Logic Low
+1          Logic High
+HL         High to Low Transition
+LH         Low to High Transition
+↑          Positive Clock Edge
+↓          Negative Clock edge
+Tin        Input Transition 30 to70 %
+Delay      50 to 50%
+Tout       Output Transition 30 to 70%
+?          Don't Care (Combinatorial Cells)
+X          Don't Care (Sequential Cells)
+default    No “when” condition for Input
+n/a        No Transition
+========== ================================


### PR DESCRIPTION
Fixes https://github.com/google/gf180mcu-pdk/issues/20

- Changed an error in `gf180mcu_fd_sc_mcu7t5v0__addf_1.rst` related to an image reference.
- Added missing file `symbols.rst`was reporting warnings.

- [x] Built locally successfully