### PR TITLE
Added missing liberty file headers.

### DIFF
--- a/liberty/gf180mcu_fd_sc_mcu7t5v0__ff_125C_1v98.lib
+++ b/liberty/gf180mcu_fd_sc_mcu7t5v0__ff_125C_1v98.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu7t5v0__ff_125C_1v98) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 125 ; 
+  nom_voltage : 1.98 ; 
+  voltage_map(VNW, 1.98);
+  voltage_map(VDD, 1.98);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu7t5v0__ff_125C_1v98) { 
+    process : 1 ; 
+    temperature : 125 ; 
+    voltage : 1.98 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 1.98 ; 
+    vimin : 0 ; 
+    vimax : 1.98 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 1.98 ; 
+    vomin : 0 ; 
+    vomax : 1.98 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.08129, 0.2964, 0.7073, 1.347, 2.245, 3.427, 4.916, 6.734, 8.9");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01016, 0.02032, 0.03048, 0.04065, 0.05081, 0.06097, 0.07113, 0.08129, 0.09145, 0.1016, 0.1118, 0.1219",\
+           "0, 0.03705, 0.07411, 0.1112, 0.1482, 0.1853, 0.2223, 0.2594, 0.2964, 0.3335, 0.3705, 0.4076, 0.4447",\
+           "0, 0.08841, 0.1768, 0.2652, 0.3536, 0.4421, 0.5305, 0.6189, 0.7073, 0.7957, 0.8841, 0.9725, 1.061",\
+           "0, 0.1684, 0.3368, 0.5053, 0.6737, 0.8421, 1.011, 1.179, 1.347, 1.516, 1.684, 1.853, 2.021",\
+           "0, 0.2807, 0.5614, 0.8421, 1.123, 1.403, 1.684, 1.965, 2.245, 2.526, 2.807, 3.088, 3.368",\
+           "0, 0.4284, 0.8568, 1.285, 1.714, 2.142, 2.57, 2.999, 3.427, 3.856, 4.284, 4.713, 5.141",\
+           "0, 0.6145, 1.229, 1.844, 2.458, 3.073, 3.687, 4.302, 4.916, 5.531, 6.145, 6.76, 7.374",\
+           "0, 0.8417, 1.683, 2.525, 3.367, 4.209, 5.05, 5.892, 6.734, 7.575, 8.417, 9.259, 10.1",\
+           "0, 1.113, 2.225, 3.337, 4.45, 5.562, 6.675, 7.787, 8.9, 10.01, 11.12, 12.24, 13.35");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.08129, 0.2964, 0.7073, 1.347, 2.245, 3.427, 4.916, 6.734, 8.9");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01016, 0.02032, 0.03048, 0.04065, 0.05081, 0.06097, 0.07113, 0.08129, 0.09145, 0.1016, 0.1118, 0.1219",\
+           "0, 0.03705, 0.07411, 0.1112, 0.1482, 0.1853, 0.2223, 0.2594, 0.2964, 0.3335, 0.3705, 0.4076, 0.4447",\
+           "0, 0.08841, 0.1768, 0.2652, 0.3536, 0.4421, 0.5305, 0.6189, 0.7073, 0.7957, 0.8841, 0.9725, 1.061",\
+           "0, 0.1684, 0.3368, 0.5053, 0.6737, 0.8421, 1.011, 1.179, 1.347, 1.516, 1.684, 1.853, 2.021",\
+           "0, 0.2807, 0.5614, 0.8421, 1.123, 1.403, 1.684, 1.965, 2.245, 2.526, 2.807, 3.088, 3.368",\
+           "0, 0.4284, 0.8568, 1.285, 1.714, 2.142, 2.57, 2.999, 3.427, 3.856, 4.284, 4.713, 5.141",\
+           "0, 0.6145, 1.229, 1.844, 2.458, 3.073, 3.687, 4.302, 4.916, 5.531, 6.145, 6.76, 7.374",\
+           "0, 0.8417, 1.683, 2.525, 3.367, 4.209, 5.05, 5.892, 6.734, 7.575, 8.417, 9.259, 10.1",\
+           "0, 1.113, 2.225, 3.337, 4.45, 5.562, 6.675, 7.787, 8.9, 10.01, 11.12, 12.24, 13.35");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu7t5v0__ff_125C_3v60.lib
+++ b/liberty/gf180mcu_fd_sc_mcu7t5v0__ff_125C_3v60.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu7t5v0__ff_125C_3v60) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 125 ; 
+  nom_voltage : 3.6 ; 
+  voltage_map(VNW, 3.6);
+  voltage_map(VDD, 3.6);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu7t5v0__ff_125C_3v60) { 
+    process : 1 ; 
+    temperature : 125 ; 
+    voltage : 3.6 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 3.6 ; 
+    vimin : 0 ; 
+    vimax : 3.6 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 3.6 ; 
+    vomin : 0 ; 
+    vomax : 3.6 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.07094, 0.2497, 0.5912, 1.123, 1.87, 2.852, 4.089, 5.6, 7.4");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.008867, 0.01773, 0.0266, 0.03547, 0.04434, 0.0532, 0.06207, 0.07094, 0.0798, 0.08867, 0.09754, 0.1064",\
+           "0, 0.03122, 0.06244, 0.09365, 0.1249, 0.1561, 0.1873, 0.2185, 0.2497, 0.281, 0.3122, 0.3434, 0.3746",\
+           "0, 0.0739, 0.1478, 0.2217, 0.2956, 0.3695, 0.4434, 0.5173, 0.5912, 0.6651, 0.739, 0.8129, 0.8868",\
+           "0, 0.1404, 0.2808, 0.4212, 0.5616, 0.702, 0.8424, 0.9828, 1.123, 1.264, 1.404, 1.544, 1.685",\
+           "0, 0.2337, 0.4674, 0.7011, 0.9348, 1.168, 1.402, 1.636, 1.87, 2.103, 2.337, 2.571, 2.804",\
+           "0, 0.3565, 0.7129, 1.069, 1.426, 1.782, 2.139, 2.495, 2.852, 3.208, 3.565, 3.921, 4.278",\
+           "0, 0.5111, 1.022, 1.533, 2.045, 2.556, 3.067, 3.578, 4.089, 4.6, 5.111, 5.622, 6.134",\
+           "0, 0.6999, 1.4, 2.1, 2.8, 3.5, 4.2, 4.9, 5.6, 6.3, 6.999, 7.699, 8.399",\
+           "0, 0.925, 1.85, 2.775, 3.7, 4.625, 5.55, 6.475, 7.4, 8.325, 9.25, 10.18, 11.1");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.07094, 0.2497, 0.5912, 1.123, 1.87, 2.852, 4.089, 5.6, 7.4");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.008867, 0.01773, 0.0266, 0.03547, 0.04434, 0.0532, 0.06207, 0.07094, 0.0798, 0.08867, 0.09754, 0.1064",\
+           "0, 0.03122, 0.06244, 0.09365, 0.1249, 0.1561, 0.1873, 0.2185, 0.2497, 0.281, 0.3122, 0.3434, 0.3746",\
+           "0, 0.0739, 0.1478, 0.2217, 0.2956, 0.3695, 0.4434, 0.5173, 0.5912, 0.6651, 0.739, 0.8129, 0.8868",\
+           "0, 0.1404, 0.2808, 0.4212, 0.5616, 0.702, 0.8424, 0.9828, 1.123, 1.264, 1.404, 1.544, 1.685",\
+           "0, 0.2337, 0.4674, 0.7011, 0.9348, 1.168, 1.402, 1.636, 1.87, 2.103, 2.337, 2.571, 2.804",\
+           "0, 0.3565, 0.7129, 1.069, 1.426, 1.782, 2.139, 2.495, 2.852, 3.208, 3.565, 3.921, 4.278",\
+           "0, 0.5111, 1.022, 1.533, 2.045, 2.556, 3.067, 3.578, 4.089, 4.6, 5.111, 5.622, 6.134",\
+           "0, 0.6999, 1.4, 2.1, 2.8, 3.5, 4.2, 4.9, 5.6, 6.3, 6.999, 7.699, 8.399",\
+           "0, 0.925, 1.85, 2.775, 3.7, 4.625, 5.55, 6.475, 7.4, 8.325, 9.25, 10.18, 11.1");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu7t5v0__ff_125C_5v50.lib
+++ b/liberty/gf180mcu_fd_sc_mcu7t5v0__ff_125C_5v50.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu7t5v0__ff_125C_5v50) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 125 ; 
+  nom_voltage : 5.5 ; 
+  voltage_map(VNW, 5.5);
+  voltage_map(VDD, 5.5);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu7t5v0__ff_125C_5v50) { 
+    process : 1 ; 
+    temperature : 125 ; 
+    voltage : 5.5 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 5.5 ; 
+    vimin : 0 ; 
+    vimax : 5.5 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 5.5 ; 
+    vomin : 0 ; 
+    vomax : 5.5 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.04333, 0.1252, 0.2816, 0.5252, 0.8671, 1.317, 1.884, 2.575, 3.4");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.005416, 0.01083, 0.01625, 0.02166, 0.02708, 0.0325, 0.03791, 0.04333, 0.04875, 0.05416, 0.05958, 0.06499",\
+           "0, 0.01565, 0.0313, 0.04696, 0.06261, 0.07826, 0.09391, 0.1096, 0.1252, 0.1409, 0.1565, 0.1722, 0.1878",\
+           "0, 0.0352, 0.0704, 0.1056, 0.1408, 0.176, 0.2112, 0.2464, 0.2816, 0.3168, 0.352, 0.3872, 0.4224",\
+           "0, 0.06565, 0.1313, 0.197, 0.2626, 0.3283, 0.3939, 0.4596, 0.5252, 0.5909, 0.6565, 0.7222, 0.7879",\
+           "0, 0.1084, 0.2168, 0.3252, 0.4335, 0.5419, 0.6503, 0.7587, 0.8671, 0.9755, 1.084, 1.192, 1.301",\
+           "0, 0.1646, 0.3292, 0.4938, 0.6585, 0.8231, 0.9877, 1.152, 1.317, 1.482, 1.646, 1.811, 1.975",\
+           "0, 0.2355, 0.4709, 0.7064, 0.9418, 1.177, 1.413, 1.648, 1.884, 2.119, 2.355, 2.59, 2.825",\
+           "0, 0.3219, 0.6439, 0.9658, 1.288, 1.61, 1.932, 2.253, 2.575, 2.897, 3.219, 3.541, 3.863",\
+           "0, 0.425, 0.85, 1.275, 1.7, 2.125, 2.55, 2.975, 3.4, 3.825, 4.25, 4.675, 5.1");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.04333, 0.1252, 0.2816, 0.5252, 0.8671, 1.317, 1.884, 2.575, 3.4");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.005416, 0.01083, 0.01625, 0.02166, 0.02708, 0.0325, 0.03791, 0.04333, 0.04875, 0.05416, 0.05958, 0.06499",\
+           "0, 0.01565, 0.0313, 0.04696, 0.06261, 0.07826, 0.09391, 0.1096, 0.1252, 0.1409, 0.1565, 0.1722, 0.1878",\
+           "0, 0.0352, 0.0704, 0.1056, 0.1408, 0.176, 0.2112, 0.2464, 0.2816, 0.3168, 0.352, 0.3872, 0.4224",\
+           "0, 0.06565, 0.1313, 0.197, 0.2626, 0.3283, 0.3939, 0.4596, 0.5252, 0.5909, 0.6565, 0.7222, 0.7879",\
+           "0, 0.1084, 0.2168, 0.3252, 0.4335, 0.5419, 0.6503, 0.7587, 0.8671, 0.9755, 1.084, 1.192, 1.301",\
+           "0, 0.1646, 0.3292, 0.4938, 0.6585, 0.8231, 0.9877, 1.152, 1.317, 1.482, 1.646, 1.811, 1.975",\
+           "0, 0.2355, 0.4709, 0.7064, 0.9418, 1.177, 1.413, 1.648, 1.884, 2.119, 2.355, 2.59, 2.825",\
+           "0, 0.3219, 0.6439, 0.9658, 1.288, 1.61, 1.932, 2.253, 2.575, 2.897, 3.219, 3.541, 3.863",\
+           "0, 0.425, 0.85, 1.275, 1.7, 2.125, 2.55, 2.975, 3.4, 3.825, 4.25, 4.675, 5.1");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu7t5v0__ff_n40C_1v98.lib
+++ b/liberty/gf180mcu_fd_sc_mcu7t5v0__ff_n40C_1v98.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu7t5v0__ff_n40C_1v98) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : -40 ; 
+  nom_voltage : 1.98 ; 
+  voltage_map(VNW, 1.98);
+  voltage_map(VDD, 1.98);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu7t5v0__ff_n40C_1v98) { 
+    process : 1 ; 
+    temperature : -40 ; 
+    voltage : 1.98 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 1.98 ; 
+    vimin : 0 ; 
+    vimax : 1.98 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 1.98 ; 
+    vomin : 0 ; 
+    vomax : 1.98 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.0668, 0.2311, 0.5448, 1.033, 1.719, 2.622, 3.758, 5.146, 6.8");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.00835, 0.0167, 0.02505, 0.0334, 0.04175, 0.0501, 0.05845, 0.0668, 0.07515, 0.0835, 0.09185, 0.1002",\
+           "0, 0.02888, 0.05777, 0.08665, 0.1155, 0.1444, 0.1733, 0.2022, 0.2311, 0.2599, 0.2888, 0.3177, 0.3466",\
+           "0, 0.06809, 0.1362, 0.2043, 0.2724, 0.3405, 0.4086, 0.4767, 0.5448, 0.6128, 0.6809, 0.749, 0.8171",\
+           "0, 0.1292, 0.2584, 0.3875, 0.5167, 0.6459, 0.7751, 0.9043, 1.033, 1.163, 1.292, 1.421, 1.55",\
+           "0, 0.2149, 0.4298, 0.6447, 0.8596, 1.074, 1.289, 1.504, 1.719, 1.934, 2.149, 2.364, 2.579",\
+           "0, 0.3277, 0.6554, 0.9831, 1.311, 1.638, 1.966, 2.294, 2.622, 2.949, 3.277, 3.605, 3.932",\
+           "0, 0.4698, 0.9396, 1.409, 1.879, 2.349, 2.819, 3.288, 3.758, 4.228, 4.698, 5.168, 5.637",\
+           "0, 0.6432, 1.286, 1.93, 2.573, 3.216, 3.859, 4.503, 5.146, 5.789, 6.432, 7.076, 7.719",\
+           "0, 0.85, 1.7, 2.55, 3.4, 4.25, 5.1, 5.95, 6.8, 7.65, 8.5, 9.35, 10.2");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.0668, 0.2311, 0.5448, 1.033, 1.719, 2.622, 3.758, 5.146, 6.8");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.00835, 0.0167, 0.02505, 0.0334, 0.04175, 0.0501, 0.05845, 0.0668, 0.07515, 0.0835, 0.09185, 0.1002",\
+           "0, 0.02888, 0.05777, 0.08665, 0.1155, 0.1444, 0.1733, 0.2022, 0.2311, 0.2599, 0.2888, 0.3177, 0.3466",\
+           "0, 0.06809, 0.1362, 0.2043, 0.2724, 0.3405, 0.4086, 0.4767, 0.5448, 0.6128, 0.6809, 0.749, 0.8171",\
+           "0, 0.1292, 0.2584, 0.3875, 0.5167, 0.6459, 0.7751, 0.9043, 1.033, 1.163, 1.292, 1.421, 1.55",\
+           "0, 0.2149, 0.4298, 0.6447, 0.8596, 1.074, 1.289, 1.504, 1.719, 1.934, 2.149, 2.364, 2.579",\
+           "0, 0.3277, 0.6554, 0.9831, 1.311, 1.638, 1.966, 2.294, 2.622, 2.949, 3.277, 3.605, 3.932",\
+           "0, 0.4698, 0.9396, 1.409, 1.879, 2.349, 2.819, 3.288, 3.758, 4.228, 4.698, 5.168, 5.637",\
+           "0, 0.6432, 1.286, 1.93, 2.573, 3.216, 3.859, 4.503, 5.146, 5.789, 6.432, 7.076, 7.719",\
+           "0, 0.85, 1.7, 2.55, 3.4, 4.25, 5.1, 5.95, 6.8, 7.65, 8.5, 9.35, 10.2");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu7t5v0__ff_n40C_3v60.lib
+++ b/liberty/gf180mcu_fd_sc_mcu7t5v0__ff_n40C_3v60.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu7t5v0__ff_n40C_3v60) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : -40 ; 
+  nom_voltage : 3.6 ; 
+  voltage_map(VNW, 3.6);
+  voltage_map(VDD, 3.6);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu7t5v0__ff_n40C_3v60) { 
+    process : 1 ; 
+    temperature : -40 ; 
+    voltage : 3.6 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 3.6 ; 
+    vimin : 0 ; 
+    vimax : 3.6 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 3.6 ; 
+    vomin : 0 ; 
+    vomax : 3.6 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.05575, 0.1813, 0.4209, 0.7943, 1.318, 2.008, 2.876, 3.936, 5.2");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.006969, 0.01394, 0.02091, 0.02788, 0.03485, 0.04181, 0.04878, 0.05575, 0.06272, 0.06969, 0.07666, 0.08363",\
+           "0, 0.02266, 0.04531, 0.06797, 0.09063, 0.1133, 0.1359, 0.1586, 0.1813, 0.2039, 0.2266, 0.2492, 0.2719",\
+           "0, 0.05261, 0.1052, 0.1578, 0.2105, 0.2631, 0.3157, 0.3683, 0.4209, 0.4735, 0.5261, 0.5788, 0.6314",\
+           "0, 0.09929, 0.1986, 0.2979, 0.3971, 0.4964, 0.5957, 0.695, 0.7943, 0.8936, 0.9929, 1.092, 1.191",\
+           "0, 0.1648, 0.3295, 0.4943, 0.6591, 0.8239, 0.9886, 1.153, 1.318, 1.483, 1.648, 1.813, 1.977",\
+           "0, 0.2509, 0.5019, 0.7528, 1.004, 1.255, 1.506, 1.757, 2.008, 2.259, 2.509, 2.76, 3.011",\
+           "0, 0.3595, 0.719, 1.079, 1.438, 1.798, 2.157, 2.517, 2.876, 3.236, 3.595, 3.955, 4.314",\
+           "0, 0.492, 0.9841, 1.476, 1.968, 2.46, 2.952, 3.444, 3.936, 4.428, 4.92, 5.412, 5.904",\
+           "0, 0.65, 1.3, 1.95, 2.6, 3.25, 3.9, 4.55, 5.2, 5.85, 6.5, 7.15, 7.8");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.05575, 0.1813, 0.4209, 0.7943, 1.318, 2.008, 2.876, 3.936, 5.2");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.006969, 0.01394, 0.02091, 0.02788, 0.03485, 0.04181, 0.04878, 0.05575, 0.06272, 0.06969, 0.07666, 0.08363",\
+           "0, 0.02266, 0.04531, 0.06797, 0.09063, 0.1133, 0.1359, 0.1586, 0.1813, 0.2039, 0.2266, 0.2492, 0.2719",\
+           "0, 0.05261, 0.1052, 0.1578, 0.2105, 0.2631, 0.3157, 0.3683, 0.4209, 0.4735, 0.5261, 0.5788, 0.6314",\
+           "0, 0.09929, 0.1986, 0.2979, 0.3971, 0.4964, 0.5957, 0.695, 0.7943, 0.8936, 0.9929, 1.092, 1.191",\
+           "0, 0.1648, 0.3295, 0.4943, 0.6591, 0.8239, 0.9886, 1.153, 1.318, 1.483, 1.648, 1.813, 1.977",\
+           "0, 0.2509, 0.5019, 0.7528, 1.004, 1.255, 1.506, 1.757, 2.008, 2.259, 2.509, 2.76, 3.011",\
+           "0, 0.3595, 0.719, 1.079, 1.438, 1.798, 2.157, 2.517, 2.876, 3.236, 3.595, 3.955, 4.314",\
+           "0, 0.492, 0.9841, 1.476, 1.968, 2.46, 2.952, 3.444, 3.936, 4.428, 4.92, 5.412, 5.904",\
+           "0, 0.65, 1.3, 1.95, 2.6, 3.25, 3.9, 4.55, 5.2, 5.85, 6.5, 7.15, 7.8");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu7t5v0__ff_n40C_5v50.lib
+++ b/liberty/gf180mcu_fd_sc_mcu7t5v0__ff_n40C_5v50.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu7t5v0__ff_n40C_5v50) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : -40 ; 
+  nom_voltage : 5.5 ; 
+  voltage_map(VNW, 5.5);
+  voltage_map(VDD, 5.5);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu7t5v0__ff_n40C_5v50) { 
+    process : 1 ; 
+    temperature : -40 ; 
+    voltage : 5.5 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 5.5 ; 
+    vimin : 0 ; 
+    vimax : 5.5 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 5.5 ; 
+    vomin : 0 ; 
+    vomax : 5.5 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.03781, 0.1003, 0.2197, 0.4057, 0.6666, 1.01, 1.443, 1.971, 2.6");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.004726, 0.009452, 0.01418, 0.0189, 0.02363, 0.02836, 0.03308, 0.03781, 0.04253, 0.04726, 0.05199, 0.05671",\
+           "0, 0.01254, 0.02508, 0.03762, 0.05016, 0.0627, 0.07524, 0.08778, 0.1003, 0.1129, 0.1254, 0.1379, 0.1505",\
+           "0, 0.02746, 0.05492, 0.08238, 0.1098, 0.1373, 0.1648, 0.1922, 0.2197, 0.2471, 0.2746, 0.3021, 0.3295",\
+           "0, 0.05071, 0.1014, 0.1521, 0.2028, 0.2535, 0.3042, 0.3549, 0.4057, 0.4564, 0.5071, 0.5578, 0.6085",\
+           "0, 0.08332, 0.1666, 0.25, 0.3333, 0.4166, 0.4999, 0.5833, 0.6666, 0.7499, 0.8332, 0.9166, 0.9999",\
+           "0, 0.1262, 0.2525, 0.3787, 0.505, 0.6312, 0.7575, 0.8837, 1.01, 1.136, 1.262, 1.389, 1.515",\
+           "0, 0.1803, 0.3606, 0.5409, 0.7213, 0.9016, 1.082, 1.262, 1.443, 1.623, 1.803, 1.983, 2.164",\
+           "0, 0.2463, 0.4926, 0.739, 0.9853, 1.232, 1.478, 1.724, 1.971, 2.217, 2.463, 2.71, 2.956",\
+           "0, 0.325, 0.65, 0.975, 1.3, 1.625, 1.95, 2.275, 2.6, 2.925, 3.25, 3.575, 3.9");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.03781, 0.1003, 0.2197, 0.4057, 0.6666, 1.01, 1.443, 1.971, 2.6");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.004726, 0.009452, 0.01418, 0.0189, 0.02363, 0.02836, 0.03308, 0.03781, 0.04253, 0.04726, 0.05199, 0.05671",\
+           "0, 0.01254, 0.02508, 0.03762, 0.05016, 0.0627, 0.07524, 0.08778, 0.1003, 0.1129, 0.1254, 0.1379, 0.1505",\
+           "0, 0.02746, 0.05492, 0.08238, 0.1098, 0.1373, 0.1648, 0.1922, 0.2197, 0.2471, 0.2746, 0.3021, 0.3295",\
+           "0, 0.05071, 0.1014, 0.1521, 0.2028, 0.2535, 0.3042, 0.3549, 0.4057, 0.4564, 0.5071, 0.5578, 0.6085",\
+           "0, 0.08332, 0.1666, 0.25, 0.3333, 0.4166, 0.4999, 0.5833, 0.6666, 0.7499, 0.8332, 0.9166, 0.9999",\
+           "0, 0.1262, 0.2525, 0.3787, 0.505, 0.6312, 0.7575, 0.8837, 1.01, 1.136, 1.262, 1.389, 1.515",\
+           "0, 0.1803, 0.3606, 0.5409, 0.7213, 0.9016, 1.082, 1.262, 1.443, 1.623, 1.803, 1.983, 2.164",\
+           "0, 0.2463, 0.4926, 0.739, 0.9853, 1.232, 1.478, 1.724, 1.971, 2.217, 2.463, 2.71, 2.956",\
+           "0, 0.325, 0.65, 0.975, 1.3, 1.625, 1.95, 2.275, 2.6, 2.925, 3.25, 3.575, 3.9");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu7t5v0__ss_125C_1v62.lib
+++ b/liberty/gf180mcu_fd_sc_mcu7t5v0__ss_125C_1v62.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu7t5v0__ss_125C_1v62) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 125 ; 
+  nom_voltage : 1.62 ; 
+  voltage_map(VNW, 1.62);
+  voltage_map(VDD, 1.62);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu7t5v0__ss_125C_1v62) { 
+    process : 1 ; 
+    temperature : 125 ; 
+    voltage : 1.62 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 1.62 ; 
+    vimin : 0 ; 
+    vimax : 1.62 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 1.62 ; 
+    vomin : 0 ; 
+    vomax : 1.62 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.1924, 0.7976, 1.953, 3.754, 6.28, 9.605, 13.79, 18.91, 25");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.02405, 0.0481, 0.07216, 0.09621, 0.1203, 0.1443, 0.1684, 0.1924, 0.2165, 0.2405, 0.2646, 0.2886",\
+           "0, 0.0997, 0.1994, 0.2991, 0.3988, 0.4985, 0.5982, 0.6979, 0.7976, 0.8973, 0.997, 1.097, 1.196",\
+           "0, 0.2442, 0.4883, 0.7325, 0.9767, 1.221, 1.465, 1.709, 1.953, 2.198, 2.442, 2.686, 2.93",\
+           "0, 0.4692, 0.9385, 1.408, 1.877, 2.346, 2.815, 3.285, 3.754, 4.223, 4.692, 5.162, 5.631",\
+           "0, 0.7851, 1.57, 2.355, 3.14, 3.925, 4.71, 5.495, 6.28, 7.065, 7.851, 8.636, 9.421",\
+           "0, 1.201, 2.401, 3.602, 4.802, 6.003, 7.204, 8.404, 9.605, 10.81, 12.01, 13.21, 14.41",\
+           "0, 1.724, 3.448, 5.172, 6.897, 8.621, 10.34, 12.07, 13.79, 15.52, 17.24, 18.97, 20.69",\
+           "0, 2.363, 4.726, 7.09, 9.453, 11.82, 14.18, 16.54, 18.91, 21.27, 23.63, 26, 28.36",\
+           "0, 3.125, 6.25, 9.375, 12.5, 15.62, 18.75, 21.88, 25, 28.12, 31.25, 34.38, 37.5");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.1924, 0.7976, 1.953, 3.754, 6.28, 9.605, 13.79, 18.91, 25");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.02405, 0.0481, 0.07216, 0.09621, 0.1203, 0.1443, 0.1684, 0.1924, 0.2165, 0.2405, 0.2646, 0.2886",\
+           "0, 0.0997, 0.1994, 0.2991, 0.3988, 0.4985, 0.5982, 0.6979, 0.7976, 0.8973, 0.997, 1.097, 1.196",\
+           "0, 0.2442, 0.4883, 0.7325, 0.9767, 1.221, 1.465, 1.709, 1.953, 2.198, 2.442, 2.686, 2.93",\
+           "0, 0.4692, 0.9385, 1.408, 1.877, 2.346, 2.815, 3.285, 3.754, 4.223, 4.692, 5.162, 5.631",\
+           "0, 0.7851, 1.57, 2.355, 3.14, 3.925, 4.71, 5.495, 6.28, 7.065, 7.851, 8.636, 9.421",\
+           "0, 1.201, 2.401, 3.602, 4.802, 6.003, 7.204, 8.404, 9.605, 10.81, 12.01, 13.21, 14.41",\
+           "0, 1.724, 3.448, 5.172, 6.897, 8.621, 10.34, 12.07, 13.79, 15.52, 17.24, 18.97, 20.69",\
+           "0, 2.363, 4.726, 7.09, 9.453, 11.82, 14.18, 16.54, 18.91, 21.27, 23.63, 26, 28.36",\
+           "0, 3.125, 6.25, 9.375, 12.5, 15.62, 18.75, 21.88, 25, 28.12, 31.25, 34.38, 37.5");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu7t5v0__ss_125C_3v00.lib
+++ b/liberty/gf180mcu_fd_sc_mcu7t5v0__ss_125C_3v00.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu7t5v0__ss_125C_3v00) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 125 ; 
+  nom_voltage : 3 ; 
+  voltage_map(VNW, 3);
+  voltage_map(VDD, 3);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu7t5v0__ss_125C_3v00) { 
+    process : 1 ; 
+    temperature : 125 ; 
+    voltage : 3 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 3 ; 
+    vimin : 0 ; 
+    vimax : 3 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 3 ; 
+    vomin : 0 ; 
+    vomax : 3 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.1275, 0.505, 1.226, 2.349, 3.925, 5.998, 8.61, 11.8, 15.6");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01594, 0.03188, 0.04783, 0.06377, 0.07971, 0.09565, 0.1116, 0.1275, 0.1435, 0.1594, 0.1754, 0.1913",\
+           "0, 0.06313, 0.1263, 0.1894, 0.2525, 0.3156, 0.3788, 0.4419, 0.505, 0.5681, 0.6313, 0.6944, 0.7575",\
+           "0, 0.1532, 0.3065, 0.4597, 0.6129, 0.7662, 0.9194, 1.073, 1.226, 1.379, 1.532, 1.686, 1.839",\
+           "0, 0.2936, 0.5872, 0.8808, 1.174, 1.468, 1.762, 2.055, 2.349, 2.642, 2.936, 3.23, 3.523",\
+           "0, 0.4906, 0.9812, 1.472, 1.962, 2.453, 2.943, 3.434, 3.925, 4.415, 4.906, 5.396, 5.887",\
+           "0, 0.7498, 1.5, 2.249, 2.999, 3.749, 4.499, 5.248, 5.998, 6.748, 7.498, 8.247, 8.997",\
+           "0, 1.076, 2.153, 3.229, 4.305, 5.381, 6.458, 7.534, 8.61, 9.687, 10.76, 11.84, 12.92",\
+           "0, 1.475, 2.95, 4.425, 5.9, 7.374, 8.849, 10.32, 11.8, 13.27, 14.75, 16.22, 17.7",\
+           "0, 1.95, 3.9, 5.85, 7.8, 9.75, 11.7, 13.65, 15.6, 17.55, 19.5, 21.45, 23.4");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.1275, 0.505, 1.226, 2.349, 3.925, 5.998, 8.61, 11.8, 15.6");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01594, 0.03188, 0.04783, 0.06377, 0.07971, 0.09565, 0.1116, 0.1275, 0.1435, 0.1594, 0.1754, 0.1913",\
+           "0, 0.06313, 0.1263, 0.1894, 0.2525, 0.3156, 0.3788, 0.4419, 0.505, 0.5681, 0.6313, 0.6944, 0.7575",\
+           "0, 0.1532, 0.3065, 0.4597, 0.6129, 0.7662, 0.9194, 1.073, 1.226, 1.379, 1.532, 1.686, 1.839",\
+           "0, 0.2936, 0.5872, 0.8808, 1.174, 1.468, 1.762, 2.055, 2.349, 2.642, 2.936, 3.23, 3.523",\
+           "0, 0.4906, 0.9812, 1.472, 1.962, 2.453, 2.943, 3.434, 3.925, 4.415, 4.906, 5.396, 5.887",\
+           "0, 0.7498, 1.5, 2.249, 2.999, 3.749, 4.499, 5.248, 5.998, 6.748, 7.498, 8.247, 8.997",\
+           "0, 1.076, 2.153, 3.229, 4.305, 5.381, 6.458, 7.534, 8.61, 9.687, 10.76, 11.84, 12.92",\
+           "0, 1.475, 2.95, 4.425, 5.9, 7.374, 8.849, 10.32, 11.8, 13.27, 14.75, 16.22, 17.7",\
+           "0, 1.95, 3.9, 5.85, 7.8, 9.75, 11.7, 13.65, 15.6, 17.55, 19.5, 21.45, 23.4");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu7t5v0__ss_125C_4v50.lib
+++ b/liberty/gf180mcu_fd_sc_mcu7t5v0__ss_125C_4v50.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu7t5v0__ss_125C_4v50) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 125 ; 
+  nom_voltage : 4.5 ; 
+  voltage_map(VNW, 4.5);
+  voltage_map(VDD, 4.5);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu7t5v0__ss_125C_4v50) { 
+    process : 1 ; 
+    temperature : 125 ; 
+    voltage : 4.5 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 4.5 ; 
+    vimin : 0 ; 
+    vimax : 4.5 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 4.5 ; 
+    vomin : 0 ; 
+    vomax : 4.5 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.06818, 0.2373, 0.5602, 1.063, 1.769, 2.698, 3.869, 5.297, 7");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.008522, 0.01704, 0.02557, 0.03409, 0.04261, 0.05113, 0.05965, 0.06818, 0.0767, 0.08522, 0.09374, 0.1023",\
+           "0, 0.02966, 0.05932, 0.08898, 0.1186, 0.1483, 0.178, 0.2076, 0.2373, 0.2669, 0.2966, 0.3263, 0.3559",\
+           "0, 0.07003, 0.1401, 0.2101, 0.2801, 0.3501, 0.4202, 0.4902, 0.5602, 0.6303, 0.7003, 0.7703, 0.8403",\
+           "0, 0.1329, 0.2658, 0.3988, 0.5317, 0.6646, 0.7975, 0.9304, 1.063, 1.196, 1.329, 1.462, 1.595",\
+           "0, 0.2212, 0.4423, 0.6635, 0.8847, 1.106, 1.327, 1.548, 1.769, 1.99, 2.212, 2.433, 2.654",\
+           "0, 0.3373, 0.6746, 1.012, 1.349, 1.686, 2.024, 2.361, 2.698, 3.036, 3.373, 3.71, 4.047",\
+           "0, 0.4836, 0.9671, 1.451, 1.934, 2.418, 2.901, 3.385, 3.869, 4.352, 4.836, 5.319, 5.803",\
+           "0, 0.6621, 1.324, 1.986, 2.649, 3.311, 3.973, 4.635, 5.297, 5.959, 6.621, 7.284, 7.946",\
+           "0, 0.875, 1.75, 2.625, 3.5, 4.375, 5.25, 6.125, 7, 7.875, 8.75, 9.625, 10.5");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.06818, 0.2373, 0.5602, 1.063, 1.769, 2.698, 3.869, 5.297, 7");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.008522, 0.01704, 0.02557, 0.03409, 0.04261, 0.05113, 0.05965, 0.06818, 0.0767, 0.08522, 0.09374, 0.1023",\
+           "0, 0.02966, 0.05932, 0.08898, 0.1186, 0.1483, 0.178, 0.2076, 0.2373, 0.2669, 0.2966, 0.3263, 0.3559",\
+           "0, 0.07003, 0.1401, 0.2101, 0.2801, 0.3501, 0.4202, 0.4902, 0.5602, 0.6303, 0.7003, 0.7703, 0.8403",\
+           "0, 0.1329, 0.2658, 0.3988, 0.5317, 0.6646, 0.7975, 0.9304, 1.063, 1.196, 1.329, 1.462, 1.595",\
+           "0, 0.2212, 0.4423, 0.6635, 0.8847, 1.106, 1.327, 1.548, 1.769, 1.99, 2.212, 2.433, 2.654",\
+           "0, 0.3373, 0.6746, 1.012, 1.349, 1.686, 2.024, 2.361, 2.698, 3.036, 3.373, 3.71, 4.047",\
+           "0, 0.4836, 0.9671, 1.451, 1.934, 2.418, 2.901, 3.385, 3.869, 4.352, 4.836, 5.319, 5.803",\
+           "0, 0.6621, 1.324, 1.986, 2.649, 3.311, 3.973, 4.635, 5.297, 5.959, 6.621, 7.284, 7.946",\
+           "0, 0.875, 1.75, 2.625, 3.5, 4.375, 5.25, 6.125, 7, 7.875, 8.75, 9.625, 10.5");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu7t5v0__ss_n40C_1v62.lib
+++ b/liberty/gf180mcu_fd_sc_mcu7t5v0__ss_n40C_1v62.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu7t5v0__ss_n40C_1v62) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : -40 ; 
+  nom_voltage : 1.62 ; 
+  voltage_map(VNW, 1.62);
+  voltage_map(VDD, 1.62);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu7t5v0__ss_n40C_1v62) { 
+    process : 1 ; 
+    temperature : -40 ; 
+    voltage : 1.62 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 1.62 ; 
+    vimin : 0 ; 
+    vimax : 1.62 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 1.62 ; 
+    vomin : 0 ; 
+    vomax : 1.62 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.1648, 0.6731, 1.644, 3.156, 5.278, 8.07, 11.59, 15.88, 21");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.0206, 0.0412, 0.0618, 0.0824, 0.103, 0.1236, 0.1442, 0.1648, 0.1854, 0.206, 0.2266, 0.2472",\
+           "0, 0.08414, 0.1683, 0.2524, 0.3366, 0.4207, 0.5048, 0.589, 0.6731, 0.7572, 0.8414, 0.9255, 1.01",\
+           "0, 0.2055, 0.4109, 0.6164, 0.8219, 1.027, 1.233, 1.438, 1.644, 1.849, 2.055, 2.26, 2.466",\
+           "0, 0.3945, 0.789, 1.184, 1.578, 1.973, 2.367, 2.762, 3.156, 3.551, 3.945, 4.34, 4.734",\
+           "0, 0.6597, 1.319, 1.979, 2.639, 3.299, 3.958, 4.618, 5.278, 5.938, 6.597, 7.257, 7.917",\
+           "0, 1.009, 2.018, 3.026, 4.035, 5.044, 6.053, 7.061, 8.07, 9.079, 10.09, 11.1, 12.11",\
+           "0, 1.448, 2.897, 4.345, 5.794, 7.242, 8.691, 10.14, 11.59, 13.04, 14.48, 15.93, 17.38",\
+           "0, 1.985, 3.97, 5.956, 7.941, 9.926, 11.91, 13.9, 15.88, 17.87, 19.85, 21.84, 23.82",\
+           "0, 2.625, 5.25, 7.875, 10.5, 13.12, 15.75, 18.38, 21, 23.62, 26.25, 28.88, 31.5");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.1648, 0.6731, 1.644, 3.156, 5.278, 8.07, 11.59, 15.88, 21");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.0206, 0.0412, 0.0618, 0.0824, 0.103, 0.1236, 0.1442, 0.1648, 0.1854, 0.206, 0.2266, 0.2472",\
+           "0, 0.08414, 0.1683, 0.2524, 0.3366, 0.4207, 0.5048, 0.589, 0.6731, 0.7572, 0.8414, 0.9255, 1.01",\
+           "0, 0.2055, 0.4109, 0.6164, 0.8219, 1.027, 1.233, 1.438, 1.644, 1.849, 2.055, 2.26, 2.466",\
+           "0, 0.3945, 0.789, 1.184, 1.578, 1.973, 2.367, 2.762, 3.156, 3.551, 3.945, 4.34, 4.734",\
+           "0, 0.6597, 1.319, 1.979, 2.639, 3.299, 3.958, 4.618, 5.278, 5.938, 6.597, 7.257, 7.917",\
+           "0, 1.009, 2.018, 3.026, 4.035, 5.044, 6.053, 7.061, 8.07, 9.079, 10.09, 11.1, 12.11",\
+           "0, 1.448, 2.897, 4.345, 5.794, 7.242, 8.691, 10.14, 11.59, 13.04, 14.48, 15.93, 17.38",\
+           "0, 1.985, 3.97, 5.956, 7.941, 9.926, 11.91, 13.9, 15.88, 17.87, 19.85, 21.84, 23.82",\
+           "0, 2.625, 5.25, 7.875, 10.5, 13.12, 15.75, 18.38, 21, 23.62, 26.25, 28.88, 31.5");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu7t5v0__ss_n40C_3v00.lib
+++ b/liberty/gf180mcu_fd_sc_mcu7t5v0__ss_n40C_3v00.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu7t5v0__ss_n40C_3v00) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : -40 ; 
+  nom_voltage : 3 ; 
+  voltage_map(VNW, 3);
+  voltage_map(VDD, 3);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu7t5v0__ss_n40C_3v00) { 
+    process : 1 ; 
+    temperature : -40 ; 
+    voltage : 3 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 3 ; 
+    vimin : 0 ; 
+    vimax : 3 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 3 ; 
+    vomin : 0 ; 
+    vomax : 3 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.09579, 0.3618, 0.8698, 1.661, 2.772, 4.233, 6.074, 8.321, 11");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01197, 0.02395, 0.03592, 0.04789, 0.05987, 0.07184, 0.08381, 0.09579, 0.1078, 0.1197, 0.1317, 0.1437",\
+           "0, 0.04523, 0.09045, 0.1357, 0.1809, 0.2261, 0.2714, 0.3166, 0.3618, 0.407, 0.4523, 0.4975, 0.5427",\
+           "0, 0.1087, 0.2175, 0.3262, 0.4349, 0.5436, 0.6524, 0.7611, 0.8698, 0.9785, 1.087, 1.196, 1.305",\
+           "0, 0.2077, 0.4153, 0.623, 0.8306, 1.038, 1.246, 1.454, 1.661, 1.869, 2.077, 2.284, 2.492",\
+           "0, 0.3465, 0.6929, 1.039, 1.386, 1.732, 2.079, 2.425, 2.772, 3.118, 3.465, 3.811, 4.158",\
+           "0, 0.5291, 1.058, 1.587, 2.117, 2.646, 3.175, 3.704, 4.233, 4.762, 5.291, 5.82, 6.35",\
+           "0, 0.7592, 1.518, 2.278, 3.037, 3.796, 4.555, 5.315, 6.074, 6.833, 7.592, 8.352, 9.111",\
+           "0, 1.04, 2.08, 3.12, 4.161, 5.201, 6.241, 7.281, 8.321, 9.361, 10.4, 11.44, 12.48",\
+           "0, 1.375, 2.75, 4.125, 5.5, 6.875, 8.25, 9.625, 11, 12.38, 13.75, 15.12, 16.5");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.09579, 0.3618, 0.8698, 1.661, 2.772, 4.233, 6.074, 8.321, 11");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01197, 0.02395, 0.03592, 0.04789, 0.05987, 0.07184, 0.08381, 0.09579, 0.1078, 0.1197, 0.1317, 0.1437",\
+           "0, 0.04523, 0.09045, 0.1357, 0.1809, 0.2261, 0.2714, 0.3166, 0.3618, 0.407, 0.4523, 0.4975, 0.5427",\
+           "0, 0.1087, 0.2175, 0.3262, 0.4349, 0.5436, 0.6524, 0.7611, 0.8698, 0.9785, 1.087, 1.196, 1.305",\
+           "0, 0.2077, 0.4153, 0.623, 0.8306, 1.038, 1.246, 1.454, 1.661, 1.869, 2.077, 2.284, 2.492",\
+           "0, 0.3465, 0.6929, 1.039, 1.386, 1.732, 2.079, 2.425, 2.772, 3.118, 3.465, 3.811, 4.158",\
+           "0, 0.5291, 1.058, 1.587, 2.117, 2.646, 3.175, 3.704, 4.233, 4.762, 5.291, 5.82, 6.35",\
+           "0, 0.7592, 1.518, 2.278, 3.037, 3.796, 4.555, 5.315, 6.074, 6.833, 7.592, 8.352, 9.111",\
+           "0, 1.04, 2.08, 3.12, 4.161, 5.201, 6.241, 7.281, 8.321, 9.361, 10.4, 11.44, 12.48",\
+           "0, 1.375, 2.75, 4.125, 5.5, 6.875, 8.25, 9.625, 11, 12.38, 13.75, 15.12, 16.5");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu7t5v0__ss_n40C_4v50.lib
+++ b/liberty/gf180mcu_fd_sc_mcu7t5v0__ss_n40C_4v50.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu7t5v0__ss_n40C_4v50) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : -40 ; 
+  nom_voltage : 4.5 ; 
+  voltage_map(VNW, 4.5);
+  voltage_map(VDD, 4.5);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu7t5v0__ss_n40C_4v50) { 
+    process : 1 ; 
+    temperature : -40 ; 
+    voltage : 4.5 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 4.5 ; 
+    vimin : 0 ; 
+    vimax : 4.5 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 4.5 ; 
+    vomin : 0 ; 
+    vomax : 4.5 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.05437, 0.175, 0.4054, 0.7644, 1.268, 1.931, 2.766, 3.785, 5");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.006797, 0.01359, 0.02039, 0.02719, 0.03398, 0.04078, 0.04758, 0.05437, 0.06117, 0.06797, 0.07476, 0.08156",\
+           "0, 0.02188, 0.04376, 0.06564, 0.08751, 0.1094, 0.1313, 0.1531, 0.175, 0.1969, 0.2188, 0.2407, 0.2625",\
+           "0, 0.05068, 0.1014, 0.152, 0.2027, 0.2534, 0.3041, 0.3548, 0.4054, 0.4561, 0.5068, 0.5575, 0.6082",\
+           "0, 0.09555, 0.1911, 0.2867, 0.3822, 0.4778, 0.5733, 0.6689, 0.7644, 0.86, 0.9555, 1.051, 1.147",\
+           "0, 0.1585, 0.317, 0.4755, 0.634, 0.7925, 0.9511, 1.11, 1.268, 1.427, 1.585, 1.744, 1.902",\
+           "0, 0.2414, 0.4827, 0.7241, 0.9654, 1.207, 1.448, 1.689, 1.931, 2.172, 2.414, 2.655, 2.896",\
+           "0, 0.3457, 0.6914, 1.037, 1.383, 1.729, 2.074, 2.42, 2.766, 3.112, 3.457, 3.803, 4.149",\
+           "0, 0.4731, 0.9463, 1.419, 1.893, 2.366, 2.839, 3.312, 3.785, 4.258, 4.731, 5.204, 5.678",\
+           "0, 0.625, 1.25, 1.875, 2.5, 3.125, 3.75, 4.375, 5, 5.625, 6.25, 6.875, 7.5");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.05437, 0.175, 0.4054, 0.7644, 1.268, 1.931, 2.766, 3.785, 5");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.006797, 0.01359, 0.02039, 0.02719, 0.03398, 0.04078, 0.04758, 0.05437, 0.06117, 0.06797, 0.07476, 0.08156",\
+           "0, 0.02188, 0.04376, 0.06564, 0.08751, 0.1094, 0.1313, 0.1531, 0.175, 0.1969, 0.2188, 0.2407, 0.2625",\
+           "0, 0.05068, 0.1014, 0.152, 0.2027, 0.2534, 0.3041, 0.3548, 0.4054, 0.4561, 0.5068, 0.5575, 0.6082",\
+           "0, 0.09555, 0.1911, 0.2867, 0.3822, 0.4778, 0.5733, 0.6689, 0.7644, 0.86, 0.9555, 1.051, 1.147",\
+           "0, 0.1585, 0.317, 0.4755, 0.634, 0.7925, 0.9511, 1.11, 1.268, 1.427, 1.585, 1.744, 1.902",\
+           "0, 0.2414, 0.4827, 0.7241, 0.9654, 1.207, 1.448, 1.689, 1.931, 2.172, 2.414, 2.655, 2.896",\
+           "0, 0.3457, 0.6914, 1.037, 1.383, 1.729, 2.074, 2.42, 2.766, 3.112, 3.457, 3.803, 4.149",\
+           "0, 0.4731, 0.9463, 1.419, 1.893, 2.366, 2.839, 3.312, 3.785, 4.258, 4.731, 5.204, 5.678",\
+           "0, 0.625, 1.25, 1.875, 2.5, 3.125, 3.75, 4.375, 5, 5.625, 6.25, 6.875, 7.5");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu7t5v0__tt_25C_1v80.lib
+++ b/liberty/gf180mcu_fd_sc_mcu7t5v0__tt_25C_1v80.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu7t5v0__tt_25C_1v80) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 25 ; 
+  nom_voltage : 1.8 ; 
+  voltage_map(VNW, 1.8);
+  voltage_map(VDD, 1.8);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu7t5v0__tt_25C_1v80) { 
+    process : 1 ; 
+    temperature : 25 ; 
+    voltage : 1.8 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 1.8 ; 
+    vimin : 0 ; 
+    vimax : 1.8 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 1.8 ; 
+    vomin : 0 ; 
+    vomax : 1.8 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.1027, 0.3929, 0.9472, 1.811, 3.022, 4.617, 6.625, 9.077, 12");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01284, 0.02567, 0.03851, 0.05134, 0.06418, 0.07702, 0.08985, 0.1027, 0.1155, 0.1284, 0.1412, 0.154",\
+           "0, 0.04912, 0.09823, 0.1474, 0.1965, 0.2456, 0.2947, 0.3438, 0.3929, 0.4421, 0.4912, 0.5403, 0.5894",\
+           "0, 0.1184, 0.2368, 0.3552, 0.4736, 0.592, 0.7104, 0.8288, 0.9472, 1.066, 1.184, 1.302, 1.421",\
+           "0, 0.2263, 0.4527, 0.679, 0.9054, 1.132, 1.358, 1.584, 1.811, 2.037, 2.263, 2.49, 2.716",\
+           "0, 0.3778, 0.7556, 1.133, 1.511, 1.889, 2.267, 2.645, 3.022, 3.4, 3.778, 4.156, 4.534",\
+           "0, 0.5771, 1.154, 1.731, 2.308, 2.885, 3.463, 4.04, 4.617, 5.194, 5.771, 6.348, 6.925",\
+           "0, 0.8282, 1.656, 2.485, 3.313, 4.141, 4.969, 5.797, 6.625, 7.454, 8.282, 9.11, 9.938",\
+           "0, 1.135, 2.269, 3.404, 4.539, 5.673, 6.808, 7.943, 9.077, 10.21, 11.35, 12.48, 13.62",\
+           "0, 1.5, 3, 4.5, 6, 7.5, 9, 10.5, 12, 13.5, 15, 16.5, 18");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.1027, 0.3929, 0.9472, 1.811, 3.022, 4.617, 6.625, 9.077, 12");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01284, 0.02567, 0.03851, 0.05134, 0.06418, 0.07702, 0.08985, 0.1027, 0.1155, 0.1284, 0.1412, 0.154",\
+           "0, 0.04912, 0.09823, 0.1474, 0.1965, 0.2456, 0.2947, 0.3438, 0.3929, 0.4421, 0.4912, 0.5403, 0.5894",\
+           "0, 0.1184, 0.2368, 0.3552, 0.4736, 0.592, 0.7104, 0.8288, 0.9472, 1.066, 1.184, 1.302, 1.421",\
+           "0, 0.2263, 0.4527, 0.679, 0.9054, 1.132, 1.358, 1.584, 1.811, 2.037, 2.263, 2.49, 2.716",\
+           "0, 0.3778, 0.7556, 1.133, 1.511, 1.889, 2.267, 2.645, 3.022, 3.4, 3.778, 4.156, 4.534",\
+           "0, 0.5771, 1.154, 1.731, 2.308, 2.885, 3.463, 4.04, 4.617, 5.194, 5.771, 6.348, 6.925",\
+           "0, 0.8282, 1.656, 2.485, 3.313, 4.141, 4.969, 5.797, 6.625, 7.454, 8.282, 9.11, 9.938",\
+           "0, 1.135, 2.269, 3.404, 4.539, 5.673, 6.808, 7.943, 9.077, 10.21, 11.35, 12.48, 13.62",\
+           "0, 1.5, 3, 4.5, 6, 7.5, 9, 10.5, 12, 13.5, 15, 16.5, 18");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu7t5v0__tt_25C_3v30.lib
+++ b/liberty/gf180mcu_fd_sc_mcu7t5v0__tt_25C_3v30.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu7t5v0__tt_25C_3v30) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 25 ; 
+  nom_voltage : 3.3 ; 
+  voltage_map(VNW, 3.3);
+  voltage_map(VDD, 3.3);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu7t5v0__tt_25C_3v30) { 
+    process : 1 ; 
+    temperature : 25 ; 
+    voltage : 3.3 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 3.3 ; 
+    vimin : 0 ; 
+    vimax : 3.3 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 3.3 ; 
+    vomin : 0 ; 
+    vomax : 3.3 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.07922, 0.2871, 0.6841, 1.303, 2.17, 3.312, 4.751, 6.507, 8.6");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.009903, 0.01981, 0.02971, 0.03961, 0.04951, 0.05942, 0.06932, 0.07922, 0.08912, 0.09903, 0.1089, 0.1188",\
+           "0, 0.03589, 0.07177, 0.1077, 0.1435, 0.1794, 0.2153, 0.2512, 0.2871, 0.323, 0.3589, 0.3948, 0.4306",\
+           "0, 0.08551, 0.171, 0.2565, 0.342, 0.4275, 0.513, 0.5986, 0.6841, 0.7696, 0.8551, 0.9406, 1.026",\
+           "0, 0.1628, 0.3256, 0.4884, 0.6513, 0.8141, 0.9769, 1.14, 1.303, 1.465, 1.628, 1.791, 1.954",\
+           "0, 0.2713, 0.5426, 0.8139, 1.085, 1.356, 1.628, 1.899, 2.17, 2.442, 2.713, 2.984, 3.255",\
+           "0, 0.414, 0.828, 1.242, 1.656, 2.07, 2.484, 2.898, 3.312, 3.726, 4.14, 4.554, 4.968",\
+           "0, 0.5938, 1.188, 1.782, 2.375, 2.969, 3.563, 4.157, 4.751, 5.345, 5.938, 6.532, 7.126",\
+           "0, 0.8134, 1.627, 2.44, 3.253, 4.067, 4.88, 5.693, 6.507, 7.32, 8.134, 8.947, 9.76",\
+           "0, 1.075, 2.15, 3.225, 4.3, 5.375, 6.45, 7.525, 8.6, 9.675, 10.75, 11.82, 12.9");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.07922, 0.2871, 0.6841, 1.303, 2.17, 3.312, 4.751, 6.507, 8.6");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.009903, 0.01981, 0.02971, 0.03961, 0.04951, 0.05942, 0.06932, 0.07922, 0.08912, 0.09903, 0.1089, 0.1188",\
+           "0, 0.03589, 0.07177, 0.1077, 0.1435, 0.1794, 0.2153, 0.2512, 0.2871, 0.323, 0.3589, 0.3948, 0.4306",\
+           "0, 0.08551, 0.171, 0.2565, 0.342, 0.4275, 0.513, 0.5986, 0.6841, 0.7696, 0.8551, 0.9406, 1.026",\
+           "0, 0.1628, 0.3256, 0.4884, 0.6513, 0.8141, 0.9769, 1.14, 1.303, 1.465, 1.628, 1.791, 1.954",\
+           "0, 0.2713, 0.5426, 0.8139, 1.085, 1.356, 1.628, 1.899, 2.17, 2.442, 2.713, 2.984, 3.255",\
+           "0, 0.414, 0.828, 1.242, 1.656, 2.07, 2.484, 2.898, 3.312, 3.726, 4.14, 4.554, 4.968",\
+           "0, 0.5938, 1.188, 1.782, 2.375, 2.969, 3.563, 4.157, 4.751, 5.345, 5.938, 6.532, 7.126",\
+           "0, 0.8134, 1.627, 2.44, 3.253, 4.067, 4.88, 5.693, 6.507, 7.32, 8.134, 8.947, 9.76",\
+           "0, 1.075, 2.15, 3.225, 4.3, 5.375, 6.45, 7.525, 8.6, 9.675, 10.75, 11.82, 12.9");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu7t5v0__tt_25C_5v00.lib
+++ b/liberty/gf180mcu_fd_sc_mcu7t5v0__tt_25C_5v00.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu7t5v0__tt_25C_5v00) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 25 ; 
+  nom_voltage : 5 ; 
+  voltage_map(VNW, 5);
+  voltage_map(VDD, 5);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu7t5v0__tt_25C_5v00) { 
+    process : 1 ; 
+    temperature : 25 ; 
+    voltage : 5 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 5 ; 
+    vimin : 0 ; 
+    vimax : 5 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 5 ; 
+    vomin : 0 ; 
+    vomax : 5 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.04747, 0.1439, 0.328, 0.6149, 1.017, 1.547, 2.214, 3.029, 4");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.005934, 0.01187, 0.0178, 0.02374, 0.02967, 0.0356, 0.04154, 0.04747, 0.0534, 0.05934, 0.06527, 0.07121",\
+           "0, 0.01799, 0.03597, 0.05396, 0.07195, 0.08994, 0.1079, 0.1259, 0.1439, 0.1619, 0.1799, 0.1979, 0.2158",\
+           "0, 0.04101, 0.08201, 0.123, 0.164, 0.205, 0.246, 0.287, 0.328, 0.369, 0.4101, 0.4511, 0.4921",\
+           "0, 0.07687, 0.1537, 0.2306, 0.3075, 0.3843, 0.4612, 0.5381, 0.6149, 0.6918, 0.7687, 0.8455, 0.9224",\
+           "0, 0.1272, 0.2544, 0.3815, 0.5087, 0.6359, 0.7631, 0.8903, 1.017, 1.145, 1.272, 1.399, 1.526",\
+           "0, 0.1934, 0.3868, 0.5802, 0.7736, 0.967, 1.16, 1.354, 1.547, 1.741, 1.934, 2.127, 2.321",\
+           "0, 0.2768, 0.5536, 0.8304, 1.107, 1.384, 1.661, 1.938, 2.214, 2.491, 2.768, 3.045, 3.322",\
+           "0, 0.3786, 0.7573, 1.136, 1.515, 1.893, 2.272, 2.65, 3.029, 3.408, 3.786, 4.165, 4.544",\
+           "0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.04747, 0.1439, 0.328, 0.6149, 1.017, 1.547, 2.214, 3.029, 4");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.005934, 0.01187, 0.0178, 0.02374, 0.02967, 0.0356, 0.04154, 0.04747, 0.0534, 0.05934, 0.06527, 0.07121",\
+           "0, 0.01799, 0.03597, 0.05396, 0.07195, 0.08994, 0.1079, 0.1259, 0.1439, 0.1619, 0.1799, 0.1979, 0.2158",\
+           "0, 0.04101, 0.08201, 0.123, 0.164, 0.205, 0.246, 0.287, 0.328, 0.369, 0.4101, 0.4511, 0.4921",\
+           "0, 0.07687, 0.1537, 0.2306, 0.3075, 0.3843, 0.4612, 0.5381, 0.6149, 0.6918, 0.7687, 0.8455, 0.9224",\
+           "0, 0.1272, 0.2544, 0.3815, 0.5087, 0.6359, 0.7631, 0.8903, 1.017, 1.145, 1.272, 1.399, 1.526",\
+           "0, 0.1934, 0.3868, 0.5802, 0.7736, 0.967, 1.16, 1.354, 1.547, 1.741, 1.934, 2.127, 2.321",\
+           "0, 0.2768, 0.5536, 0.8304, 1.107, 1.384, 1.661, 1.938, 2.214, 2.491, 2.768, 3.045, 3.322",\
+           "0, 0.3786, 0.7573, 1.136, 1.515, 1.893, 2.272, 2.65, 3.029, 3.408, 3.786, 4.165, 4.544",\
+           "0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6");
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/google/gf180mcu-pdk/issues/65

Note that this does not address how to build the timing libraries, but adds the critical information necessary to do so.  The files are in the form of a complete liberty header but with the cells() sections removed, as those sections exist in each of the directories in cells/.

A "make timing" script would need to insert the contents of the individual cells' liberty files in front of the closing brace of the header file.  It is not possible to write a script that generates the entire header on the fly, because each header contains data unique to each liberty library.