### PR TITLE
cells: rename functional module

### DIFF
--- a/cells/addf/gf180mcu_fd_sc_mcu7t5v0__addf_1.functional.pp.v
+++ b/cells/addf/gf180mcu_fd_sc_mcu7t5v0__addf_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__addf_1( S, A, CI, B, CO, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__addf_1_func( S, A, CI, B, CO, VDD, VSS );
 input A, B, CI;
 inout VDD, VSS;
 output CO, S;

--- a/cells/addf/gf180mcu_fd_sc_mcu7t5v0__addf_2.functional.pp.v
+++ b/cells/addf/gf180mcu_fd_sc_mcu7t5v0__addf_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__addf_2( S, A, CI, B, CO, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__addf_2_func( S, A, CI, B, CO, VDD, VSS );
 input A, B, CI;
 inout VDD, VSS;
 output CO, S;

--- a/cells/addf/gf180mcu_fd_sc_mcu7t5v0__addf_4.functional.pp.v
+++ b/cells/addf/gf180mcu_fd_sc_mcu7t5v0__addf_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__addf_4( S, A, CI, B, CO, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__addf_4_func( S, A, CI, B, CO, VDD, VSS );
 input A, B, CI;
 inout VDD, VSS;
 output CO, S;

--- a/cells/addh/gf180mcu_fd_sc_mcu7t5v0__addh_1.functional.pp.v
+++ b/cells/addh/gf180mcu_fd_sc_mcu7t5v0__addh_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__addh_1( CO, A, B, S, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__addh_1_func( CO, A, B, S, VDD, VSS );
 input A, B;
 inout VDD, VSS;
 output CO, S;

--- a/cells/addh/gf180mcu_fd_sc_mcu7t5v0__addh_2.functional.pp.v
+++ b/cells/addh/gf180mcu_fd_sc_mcu7t5v0__addh_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__addh_2( CO, A, B, S, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__addh_2_func( CO, A, B, S, VDD, VSS );
 input A, B;
 inout VDD, VSS;
 output CO, S;

--- a/cells/addh/gf180mcu_fd_sc_mcu7t5v0__addh_4.functional.pp.v
+++ b/cells/addh/gf180mcu_fd_sc_mcu7t5v0__addh_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__addh_4( A, B, CO, S, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__addh_4_func( A, B, CO, S, VDD, VSS );
 input A, B;
 inout VDD, VSS;
 output CO, S;

--- a/cells/and2/gf180mcu_fd_sc_mcu7t5v0__and2_1.functional.pp.v
+++ b/cells/and2/gf180mcu_fd_sc_mcu7t5v0__and2_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__and2_1( A1, A2, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__and2_1_func( A1, A2, Z, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output Z;

--- a/cells/and2/gf180mcu_fd_sc_mcu7t5v0__and2_2.functional.pp.v
+++ b/cells/and2/gf180mcu_fd_sc_mcu7t5v0__and2_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__and2_2( A1, A2, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__and2_2_func( A1, A2, Z, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output Z;

--- a/cells/and2/gf180mcu_fd_sc_mcu7t5v0__and2_4.functional.pp.v
+++ b/cells/and2/gf180mcu_fd_sc_mcu7t5v0__and2_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__and2_4( A2, A1, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__and2_4_func( A2, A1, Z, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output Z;

--- a/cells/and3/gf180mcu_fd_sc_mcu7t5v0__and3_1.functional.pp.v
+++ b/cells/and3/gf180mcu_fd_sc_mcu7t5v0__and3_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__and3_1( A1, A2, A3, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__and3_1_func( A1, A2, A3, Z, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output Z;

--- a/cells/and3/gf180mcu_fd_sc_mcu7t5v0__and3_2.functional.pp.v
+++ b/cells/and3/gf180mcu_fd_sc_mcu7t5v0__and3_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__and3_2( A1, A2, A3, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__and3_2_func( A1, A2, A3, Z, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output Z;

--- a/cells/and3/gf180mcu_fd_sc_mcu7t5v0__and3_4.functional.pp.v
+++ b/cells/and3/gf180mcu_fd_sc_mcu7t5v0__and3_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__and3_4( A3, A2, A1, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__and3_4_func( A3, A2, A1, Z, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output Z;

--- a/cells/and4/gf180mcu_fd_sc_mcu7t5v0__and4_1.functional.pp.v
+++ b/cells/and4/gf180mcu_fd_sc_mcu7t5v0__and4_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__and4_1( A1, A2, A3, A4, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__and4_1_func( A1, A2, A3, A4, Z, VDD, VSS );
 input A1, A2, A3, A4;
 inout VDD, VSS;
 output Z;

--- a/cells/and4/gf180mcu_fd_sc_mcu7t5v0__and4_2.functional.pp.v
+++ b/cells/and4/gf180mcu_fd_sc_mcu7t5v0__and4_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__and4_2( A1, A2, A3, A4, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__and4_2_func( A1, A2, A3, A4, Z, VDD, VSS );
 input A1, A2, A3, A4;
 inout VDD, VSS;
 output Z;

--- a/cells/and4/gf180mcu_fd_sc_mcu7t5v0__and4_4.functional.pp.v
+++ b/cells/and4/gf180mcu_fd_sc_mcu7t5v0__and4_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__and4_4( A4, A3, A1, A2, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__and4_4_func( A4, A3, A1, A2, Z, VDD, VSS );
 input A1, A2, A3, A4;
 inout VDD, VSS;
 output Z;

--- a/cells/antenna/gf180mcu_fd_sc_mcu7t5v0__antenna.functional.pp.v
+++ b/cells/antenna/gf180mcu_fd_sc_mcu7t5v0__antenna.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__antenna( I, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__antenna_func( I, VDD, VSS );
 input I;
 inout VDD, VSS;
 

--- a/cells/aoi21/gf180mcu_fd_sc_mcu7t5v0__aoi21_1.functional.pp.v
+++ b/cells/aoi21/gf180mcu_fd_sc_mcu7t5v0__aoi21_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__aoi21_1( A2, ZN, A1, B, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__aoi21_1_func( A2, ZN, A1, B, VDD, VSS );
 input A1, A2, B;
 inout VDD, VSS;
 output ZN;

--- a/cells/aoi21/gf180mcu_fd_sc_mcu7t5v0__aoi21_2.functional.pp.v
+++ b/cells/aoi21/gf180mcu_fd_sc_mcu7t5v0__aoi21_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__aoi21_2( B, ZN, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__aoi21_2_func( B, ZN, A2, A1, VDD, VSS );
 input A1, A2, B;
 inout VDD, VSS;
 output ZN;

--- a/cells/aoi21/gf180mcu_fd_sc_mcu7t5v0__aoi21_4.functional.pp.v
+++ b/cells/aoi21/gf180mcu_fd_sc_mcu7t5v0__aoi21_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__aoi21_4( A2, A1, ZN, B, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__aoi21_4_func( A2, A1, ZN, B, VDD, VSS );
 input A1, A2, B;
 inout VDD, VSS;
 output ZN;

--- a/cells/aoi211/gf180mcu_fd_sc_mcu7t5v0__aoi211_1.functional.pp.v
+++ b/cells/aoi211/gf180mcu_fd_sc_mcu7t5v0__aoi211_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__aoi211_1( A2, ZN, A1, B, C, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__aoi211_1_func( A2, ZN, A1, B, C, VDD, VSS );
 input A1, A2, B, C;
 inout VDD, VSS;
 output ZN;

--- a/cells/aoi211/gf180mcu_fd_sc_mcu7t5v0__aoi211_2.functional.pp.v
+++ b/cells/aoi211/gf180mcu_fd_sc_mcu7t5v0__aoi211_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__aoi211_2( A2, A1, ZN, B, C, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__aoi211_2_func( A2, A1, ZN, B, C, VDD, VSS );
 input A1, A2, B, C;
 inout VDD, VSS;
 output ZN;

--- a/cells/aoi211/gf180mcu_fd_sc_mcu7t5v0__aoi211_4.functional.pp.v
+++ b/cells/aoi211/gf180mcu_fd_sc_mcu7t5v0__aoi211_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__aoi211_4( ZN, A2, A1, B, C, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__aoi211_4_func( ZN, A2, A1, B, C, VDD, VSS );
 input A1, A2, B, C;
 inout VDD, VSS;
 output ZN;

--- a/cells/aoi22/gf180mcu_fd_sc_mcu7t5v0__aoi22_1.functional.pp.v
+++ b/cells/aoi22/gf180mcu_fd_sc_mcu7t5v0__aoi22_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__aoi22_1( B2, B1, ZN, A1, A2, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__aoi22_1_func( B2, B1, ZN, A1, A2, VDD, VSS );
 input A1, A2, B1, B2;
 inout VDD, VSS;
 output ZN;

--- a/cells/aoi22/gf180mcu_fd_sc_mcu7t5v0__aoi22_2.functional.pp.v
+++ b/cells/aoi22/gf180mcu_fd_sc_mcu7t5v0__aoi22_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__aoi22_2( B2, B1, ZN, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__aoi22_2_func( B2, B1, ZN, A2, A1, VDD, VSS );
 input A1, A2, B1, B2;
 inout VDD, VSS;
 output ZN;

--- a/cells/aoi22/gf180mcu_fd_sc_mcu7t5v0__aoi22_4.functional.pp.v
+++ b/cells/aoi22/gf180mcu_fd_sc_mcu7t5v0__aoi22_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__aoi22_4( B2, B1, ZN, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__aoi22_4_func( B2, B1, ZN, A2, A1, VDD, VSS );
 input A1, A2, B1, B2;
 inout VDD, VSS;
 output ZN;

--- a/cells/aoi221/gf180mcu_fd_sc_mcu7t5v0__aoi221_1.functional.pp.v
+++ b/cells/aoi221/gf180mcu_fd_sc_mcu7t5v0__aoi221_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__aoi221_1( B2, B1, ZN, C, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__aoi221_1_func( B2, B1, ZN, C, A2, A1, VDD, VSS );
 input A1, A2, B1, B2, C;
 inout VDD, VSS;
 output ZN;

--- a/cells/aoi221/gf180mcu_fd_sc_mcu7t5v0__aoi221_2.functional.pp.v
+++ b/cells/aoi221/gf180mcu_fd_sc_mcu7t5v0__aoi221_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__aoi221_2( ZN, B2, C, B1, A1, A2, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__aoi221_2_func( ZN, B2, C, B1, A1, A2, VDD, VSS );
 input A1, A2, B1, B2, C;
 inout VDD, VSS;
 output ZN;

--- a/cells/aoi221/gf180mcu_fd_sc_mcu7t5v0__aoi221_4.functional.pp.v
+++ b/cells/aoi221/gf180mcu_fd_sc_mcu7t5v0__aoi221_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__aoi221_4( ZN, B2, B1, C, A1, A2, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__aoi221_4_func( ZN, B2, B1, C, A1, A2, VDD, VSS );
 input A1, A2, B1, B2, C;
 inout VDD, VSS;
 output ZN;

--- a/cells/aoi222/gf180mcu_fd_sc_mcu7t5v0__aoi222_1.functional.pp.v
+++ b/cells/aoi222/gf180mcu_fd_sc_mcu7t5v0__aoi222_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__aoi222_1( C2, C1, B1, ZN, B2, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__aoi222_1_func( C2, C1, B1, ZN, B2, A2, A1, VDD, VSS );
 input A1, A2, B1, B2, C1, C2;
 inout VDD, VSS;
 output ZN;

--- a/cells/aoi222/gf180mcu_fd_sc_mcu7t5v0__aoi222_2.functional.pp.v
+++ b/cells/aoi222/gf180mcu_fd_sc_mcu7t5v0__aoi222_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__aoi222_2( ZN, C2, C1, B2, B1, A1, A2, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__aoi222_2_func( ZN, C2, C1, B2, B1, A1, A2, VDD, VSS );
 input A1, A2, B1, B2, C1, C2;
 inout VDD, VSS;
 output ZN;

--- a/cells/aoi222/gf180mcu_fd_sc_mcu7t5v0__aoi222_4.functional.pp.v
+++ b/cells/aoi222/gf180mcu_fd_sc_mcu7t5v0__aoi222_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__aoi222_4( ZN, C2, C1, B1, B2, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__aoi222_4_func( ZN, C2, C1, B1, B2, A2, A1, VDD, VSS );
 input A1, A2, B1, B2, C1, C2;
 inout VDD, VSS;
 output ZN;

--- a/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_1.functional.pp.v
+++ b/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__buf_1( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__buf_1_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_12.functional.pp.v
+++ b/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_12.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__buf_12( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__buf_12_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_16.functional.pp.v
+++ b/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_16.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__buf_16( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__buf_16_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_2.functional.pp.v
+++ b/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__buf_2( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__buf_2_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_20.functional.pp.v
+++ b/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_20.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__buf_20( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__buf_20_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_3.functional.pp.v
+++ b/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_3.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__buf_3( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__buf_3_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_4.functional.pp.v
+++ b/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__buf_4( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__buf_4_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_8.functional.pp.v
+++ b/cells/buf/gf180mcu_fd_sc_mcu7t5v0__buf_8.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__buf_8( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__buf_8_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_1.functional.pp.v
+++ b/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__bufz_1( EN, I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__bufz_1_func( EN, I, Z, VDD, VSS );
 input EN, I;
 inout VDD, VSS;
 output Z;

--- a/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_12.functional.pp.v
+++ b/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_12.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__bufz_12( EN, I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__bufz_12_func( EN, I, Z, VDD, VSS );
 input EN, I;
 inout VDD, VSS;
 output Z;

--- a/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_16.functional.pp.v
+++ b/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_16.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__bufz_16( EN, I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__bufz_16_func( EN, I, Z, VDD, VSS );
 input EN, I;
 inout VDD, VSS;
 output Z;

--- a/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_2.functional.pp.v
+++ b/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__bufz_2( EN, I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__bufz_2_func( EN, I, Z, VDD, VSS );
 input EN, I;
 inout VDD, VSS;
 output Z;

--- a/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_3.functional.pp.v
+++ b/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_3.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__bufz_3( EN, I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__bufz_3_func( EN, I, Z, VDD, VSS );
 input EN, I;
 inout VDD, VSS;
 output Z;

--- a/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_4.functional.pp.v
+++ b/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__bufz_4( EN, I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__bufz_4_func( EN, I, Z, VDD, VSS );
 input EN, I;
 inout VDD, VSS;
 output Z;

--- a/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_8.functional.pp.v
+++ b/cells/bufz/gf180mcu_fd_sc_mcu7t5v0__bufz_8.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__bufz_8( EN, I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__bufz_8_func( EN, I, Z, VDD, VSS );
 input EN, I;
 inout VDD, VSS;
 output Z;

--- a/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_1.functional.pp.v
+++ b/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkbuf_1( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkbuf_1_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_12.functional.pp.v
+++ b/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_12.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkbuf_12( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkbuf_12_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_16.functional.pp.v
+++ b/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_16.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkbuf_16( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkbuf_16_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_2.functional.pp.v
+++ b/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkbuf_2( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkbuf_2_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_20.functional.pp.v
+++ b/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_20.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkbuf_20( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkbuf_20_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_3.functional.pp.v
+++ b/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_3.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkbuf_3( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkbuf_3_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_4.functional.pp.v
+++ b/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkbuf_4( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkbuf_4_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_8.functional.pp.v
+++ b/cells/clkbuf/gf180mcu_fd_sc_mcu7t5v0__clkbuf_8.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkbuf_8( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkbuf_8_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_1.functional.pp.v
+++ b/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkinv_1( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkinv_1_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_12.functional.pp.v
+++ b/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_12.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkinv_12( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkinv_12_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_16.functional.pp.v
+++ b/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_16.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkinv_16( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkinv_16_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_2.functional.pp.v
+++ b/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkinv_2( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkinv_2_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_20.functional.pp.v
+++ b/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_20.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkinv_20( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkinv_20_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_3.functional.pp.v
+++ b/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_3.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkinv_3( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkinv_3_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_4.functional.pp.v
+++ b/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkinv_4( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkinv_4_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_8.functional.pp.v
+++ b/cells/clkinv/gf180mcu_fd_sc_mcu7t5v0__clkinv_8.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__clkinv_8( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__clkinv_8_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/dffnq/gf180mcu_fd_sc_mcu7t5v0__dffnq_1.functional.pp.v
+++ b/cells/dffnq/gf180mcu_fd_sc_mcu7t5v0__dffnq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffnq_1( CLKN, D, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffnq_1_func( CLKN, D, Q, VDD, VSS, notifier );
 input CLKN, D, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffnq/gf180mcu_fd_sc_mcu7t5v0__dffnq_2.functional.pp.v
+++ b/cells/dffnq/gf180mcu_fd_sc_mcu7t5v0__dffnq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffnq_2( CLKN, D, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffnq_2_func( CLKN, D, Q, VDD, VSS, notifier );
 input CLKN, D, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffnq/gf180mcu_fd_sc_mcu7t5v0__dffnq_4.functional.pp.v
+++ b/cells/dffnq/gf180mcu_fd_sc_mcu7t5v0__dffnq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffnq_4( CLKN, D, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffnq_4_func( CLKN, D, Q, VDD, VSS, notifier );
 input CLKN, D, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffnrnq/gf180mcu_fd_sc_mcu7t5v0__dffnrnq_1.functional.pp.v
+++ b/cells/dffnrnq/gf180mcu_fd_sc_mcu7t5v0__dffnrnq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffnrnq_1( CLKN, D, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffnrnq_1_func( CLKN, D, RN, Q, VDD, VSS, notifier );
 input CLKN, D, RN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffnrnq/gf180mcu_fd_sc_mcu7t5v0__dffnrnq_2.functional.pp.v
+++ b/cells/dffnrnq/gf180mcu_fd_sc_mcu7t5v0__dffnrnq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffnrnq_2( CLKN, D, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffnrnq_2_func( CLKN, D, RN, Q, VDD, VSS, notifier );
 input CLKN, D, RN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffnrnq/gf180mcu_fd_sc_mcu7t5v0__dffnrnq_4.functional.pp.v
+++ b/cells/dffnrnq/gf180mcu_fd_sc_mcu7t5v0__dffnrnq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffnrnq_4( CLKN, D, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffnrnq_4_func( CLKN, D, RN, Q, VDD, VSS, notifier );
 input CLKN, D, RN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffnrsnq/gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_1.functional.pp.v
+++ b/cells/dffnrsnq/gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_1( CLKN, D, SETN, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_1_func( CLKN, D, SETN, RN, Q, VDD, VSS, notifier );
 input CLKN, D, RN, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffnrsnq/gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_2.functional.pp.v
+++ b/cells/dffnrsnq/gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_2( CLKN, D, SETN, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_2_func( CLKN, D, SETN, RN, Q, VDD, VSS, notifier );
 input CLKN, D, RN, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffnrsnq/gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_4.functional.pp.v
+++ b/cells/dffnrsnq/gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_4( CLKN, D, SETN, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffnrsnq_4_func( CLKN, D, SETN, RN, Q, VDD, VSS, notifier );
 input CLKN, D, RN, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffnsnq/gf180mcu_fd_sc_mcu7t5v0__dffnsnq_1.functional.pp.v
+++ b/cells/dffnsnq/gf180mcu_fd_sc_mcu7t5v0__dffnsnq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffnsnq_1( CLKN, D, SETN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffnsnq_1_func( CLKN, D, SETN, Q, VDD, VSS, notifier );
 input CLKN, D, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffnsnq/gf180mcu_fd_sc_mcu7t5v0__dffnsnq_2.functional.pp.v
+++ b/cells/dffnsnq/gf180mcu_fd_sc_mcu7t5v0__dffnsnq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffnsnq_2( CLKN, D, SETN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffnsnq_2_func( CLKN, D, SETN, Q, VDD, VSS, notifier );
 input CLKN, D, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffnsnq/gf180mcu_fd_sc_mcu7t5v0__dffnsnq_4.functional.pp.v
+++ b/cells/dffnsnq/gf180mcu_fd_sc_mcu7t5v0__dffnsnq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffnsnq_4( CLKN, D, SETN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffnsnq_4_func( CLKN, D, SETN, Q, VDD, VSS, notifier );
 input CLKN, D, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__dffq_1.functional.pp.v
+++ b/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__dffq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffq_1( CLK, D, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffq_1_func( CLK, D, Q, VDD, VSS, notifier );
 input CLK, D, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__dffq_2.functional.pp.v
+++ b/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__dffq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffq_2( CLK, D, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffq_2_func( CLK, D, Q, VDD, VSS, notifier );
 input CLK, D, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__dffq_4.functional.pp.v
+++ b/cells/dffq/gf180mcu_fd_sc_mcu7t5v0__dffq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffq_4( CLK, D, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffq_4_func( CLK, D, Q, VDD, VSS, notifier );
 input CLK, D, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__dffrnq_1.functional.pp.v
+++ b/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__dffrnq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffrnq_1( CLK, D, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffrnq_1_func( CLK, D, RN, Q, VDD, VSS, notifier );
 input CLK, D, RN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__dffrnq_2.functional.pp.v
+++ b/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__dffrnq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffrnq_2( CLK, D, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffrnq_2_func( CLK, D, RN, Q, VDD, VSS, notifier );
 input CLK, D, RN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__dffrnq_4.functional.pp.v
+++ b/cells/dffrnq/gf180mcu_fd_sc_mcu7t5v0__dffrnq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffrnq_4( CLK, D, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffrnq_4_func( CLK, D, RN, Q, VDD, VSS, notifier );
 input CLK, D, RN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__dffrsnq_1.functional.pp.v
+++ b/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__dffrsnq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffrsnq_1( CLK, D, SETN, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffrsnq_1_func( CLK, D, SETN, RN, Q, VDD, VSS, notifier );
 input CLK, D, RN, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__dffrsnq_2.functional.pp.v
+++ b/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__dffrsnq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffrsnq_2( CLK, D, SETN, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffrsnq_2_func( CLK, D, SETN, RN, Q, VDD, VSS, notifier );
 input CLK, D, RN, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__dffrsnq_4.functional.pp.v
+++ b/cells/dffrsnq/gf180mcu_fd_sc_mcu7t5v0__dffrsnq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffrsnq_4( CLK, D, SETN, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffrsnq_4_func( CLK, D, SETN, RN, Q, VDD, VSS, notifier );
 input CLK, D, RN, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__dffsnq_1.functional.pp.v
+++ b/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__dffsnq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffsnq_1( CLK, D, SETN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffsnq_1_func( CLK, D, SETN, Q, VDD, VSS, notifier );
 input CLK, D, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__dffsnq_2.functional.pp.v
+++ b/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__dffsnq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffsnq_2( CLK, D, SETN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffsnq_2_func( CLK, D, SETN, Q, VDD, VSS, notifier );
 input CLK, D, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__dffsnq_4.functional.pp.v
+++ b/cells/dffsnq/gf180mcu_fd_sc_mcu7t5v0__dffsnq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dffsnq_4( CLK, D, SETN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__dffsnq_4_func( CLK, D, SETN, Q, VDD, VSS, notifier );
 input CLK, D, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/dlya/gf180mcu_fd_sc_mcu7t5v0__dlya_1.functional.pp.v
+++ b/cells/dlya/gf180mcu_fd_sc_mcu7t5v0__dlya_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dlya_1( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__dlya_1_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/dlya/gf180mcu_fd_sc_mcu7t5v0__dlya_2.functional.pp.v
+++ b/cells/dlya/gf180mcu_fd_sc_mcu7t5v0__dlya_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dlya_2( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__dlya_2_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/dlya/gf180mcu_fd_sc_mcu7t5v0__dlya_4.functional.pp.v
+++ b/cells/dlya/gf180mcu_fd_sc_mcu7t5v0__dlya_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dlya_4( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__dlya_4_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/dlyb/gf180mcu_fd_sc_mcu7t5v0__dlyb_1.functional.pp.v
+++ b/cells/dlyb/gf180mcu_fd_sc_mcu7t5v0__dlyb_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dlyb_1( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__dlyb_1_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/dlyb/gf180mcu_fd_sc_mcu7t5v0__dlyb_2.functional.pp.v
+++ b/cells/dlyb/gf180mcu_fd_sc_mcu7t5v0__dlyb_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dlyb_2( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__dlyb_2_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/dlyb/gf180mcu_fd_sc_mcu7t5v0__dlyb_4.functional.pp.v
+++ b/cells/dlyb/gf180mcu_fd_sc_mcu7t5v0__dlyb_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dlyb_4( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__dlyb_4_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/dlyc/gf180mcu_fd_sc_mcu7t5v0__dlyc_1.functional.pp.v
+++ b/cells/dlyc/gf180mcu_fd_sc_mcu7t5v0__dlyc_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dlyc_1( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__dlyc_1_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/dlyc/gf180mcu_fd_sc_mcu7t5v0__dlyc_2.functional.pp.v
+++ b/cells/dlyc/gf180mcu_fd_sc_mcu7t5v0__dlyc_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dlyc_2( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__dlyc_2_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/dlyc/gf180mcu_fd_sc_mcu7t5v0__dlyc_4.functional.pp.v
+++ b/cells/dlyc/gf180mcu_fd_sc_mcu7t5v0__dlyc_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dlyc_4( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__dlyc_4_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/dlyd/gf180mcu_fd_sc_mcu7t5v0__dlyd_1.functional.pp.v
+++ b/cells/dlyd/gf180mcu_fd_sc_mcu7t5v0__dlyd_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dlyd_1( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__dlyd_1_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/dlyd/gf180mcu_fd_sc_mcu7t5v0__dlyd_2.functional.pp.v
+++ b/cells/dlyd/gf180mcu_fd_sc_mcu7t5v0__dlyd_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dlyd_2( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__dlyd_2_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/dlyd/gf180mcu_fd_sc_mcu7t5v0__dlyd_4.functional.pp.v
+++ b/cells/dlyd/gf180mcu_fd_sc_mcu7t5v0__dlyd_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__dlyd_4( I, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__dlyd_4_func( I, Z, VDD, VSS );
 input I;
 inout VDD, VSS;
 output Z;

--- a/cells/endcap/gf180mcu_fd_sc_mcu7t5v0__endcap.functional.pp.v
+++ b/cells/endcap/gf180mcu_fd_sc_mcu7t5v0__endcap.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__endcap( VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__endcap_func( VDD, VSS );
 inout VDD, VSS;
 
 endmodule

--- a/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_1.functional.pp.v
+++ b/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__fill_1( VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__fill_1_func( VDD, VSS );
 inout VDD, VSS;
 
 endmodule

--- a/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_16.functional.pp.v
+++ b/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_16.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__fill_16( VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__fill_16_func( VDD, VSS );
 inout VDD, VSS;
 
 endmodule

--- a/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_2.functional.pp.v
+++ b/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__fill_2( VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__fill_2_func( VDD, VSS );
 inout VDD, VSS;
 
 endmodule

--- a/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_32.functional.pp.v
+++ b/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_32.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__fill_32( VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__fill_32_func( VDD, VSS );
 inout VDD, VSS;
 
 endmodule

--- a/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_4.functional.pp.v
+++ b/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__fill_4( VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__fill_4_func( VDD, VSS );
 inout VDD, VSS;
 
 endmodule

--- a/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_64.functional.pp.v
+++ b/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_64.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__fill_64( VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__fill_64_func( VDD, VSS );
 inout VDD, VSS;
 
 endmodule

--- a/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_8.functional.pp.v
+++ b/cells/fill/gf180mcu_fd_sc_mcu7t5v0__fill_8.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__fill_8( VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__fill_8_func( VDD, VSS );
 inout VDD, VSS;
 
 endmodule

--- a/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_16.functional.pp.v
+++ b/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_16.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__fillcap_16( VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__fillcap_16_func( VDD, VSS );
 inout VDD, VSS;
 
 endmodule

--- a/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_32.functional.pp.v
+++ b/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_32.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__fillcap_32( VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__fillcap_32_func( VDD, VSS );
 inout VDD, VSS;
 
 endmodule

--- a/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_4.functional.pp.v
+++ b/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__fillcap_4( VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__fillcap_4_func( VDD, VSS );
 inout VDD, VSS;
 
 endmodule

--- a/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_64.functional.pp.v
+++ b/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_64.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__fillcap_64( VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__fillcap_64_func( VDD, VSS );
 inout VDD, VSS;
 
 endmodule

--- a/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_8.functional.pp.v
+++ b/cells/fillcap/gf180mcu_fd_sc_mcu7t5v0__fillcap_8.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__fillcap_8( VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__fillcap_8_func( VDD, VSS );
 inout VDD, VSS;
 
 endmodule

--- a/cells/filltie/gf180mcu_fd_sc_mcu7t5v0__filltie.functional.pp.v
+++ b/cells/filltie/gf180mcu_fd_sc_mcu7t5v0__filltie.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__filltie( VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__filltie_func( VDD, VSS );
 inout VDD, VSS;
 
 endmodule

--- a/cells/hold/gf180mcu_fd_sc_mcu7t5v0__hold.functional.pp.v
+++ b/cells/hold/gf180mcu_fd_sc_mcu7t5v0__hold.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__hold( Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__hold_func( Z, VDD, VSS );
 inout VDD, VSS;
 inout Z;
 

--- a/cells/icgtn/gf180mcu_fd_sc_mcu7t5v0__icgtn_1.functional.pp.v
+++ b/cells/icgtn/gf180mcu_fd_sc_mcu7t5v0__icgtn_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__icgtn_1( TE, E, CLKN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__icgtn_1_func( TE, E, CLKN, Q, VDD, VSS, notifier );
 input CLKN, E, TE, VDD, VSS, notifier;
 output Q;
 

--- a/cells/icgtn/gf180mcu_fd_sc_mcu7t5v0__icgtn_2.functional.pp.v
+++ b/cells/icgtn/gf180mcu_fd_sc_mcu7t5v0__icgtn_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__icgtn_2( TE, E, CLKN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__icgtn_2_func( TE, E, CLKN, Q, VDD, VSS, notifier );
 input CLKN, E, TE, VDD, VSS, notifier;
 output Q;
 

--- a/cells/icgtn/gf180mcu_fd_sc_mcu7t5v0__icgtn_4.functional.pp.v
+++ b/cells/icgtn/gf180mcu_fd_sc_mcu7t5v0__icgtn_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__icgtn_4( TE, E, CLKN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__icgtn_4_func( TE, E, CLKN, Q, VDD, VSS, notifier );
 input CLKN, E, TE, VDD, VSS, notifier;
 output Q;
 

--- a/cells/icgtp/gf180mcu_fd_sc_mcu7t5v0__icgtp_1.functional.pp.v
+++ b/cells/icgtp/gf180mcu_fd_sc_mcu7t5v0__icgtp_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__icgtp_1( TE, E, CLK, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__icgtp_1_func( TE, E, CLK, Q, VDD, VSS, notifier );
 input CLK, E, TE, VDD, VSS, notifier;
 output Q;
 

--- a/cells/icgtp/gf180mcu_fd_sc_mcu7t5v0__icgtp_2.functional.pp.v
+++ b/cells/icgtp/gf180mcu_fd_sc_mcu7t5v0__icgtp_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__icgtp_2( TE, E, CLK, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__icgtp_2_func( TE, E, CLK, Q, VDD, VSS, notifier );
 input CLK, E, TE, VDD, VSS, notifier;
 output Q;
 

--- a/cells/icgtp/gf180mcu_fd_sc_mcu7t5v0__icgtp_4.functional.pp.v
+++ b/cells/icgtp/gf180mcu_fd_sc_mcu7t5v0__icgtp_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__icgtp_4( TE, E, CLK, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__icgtp_4_func( TE, E, CLK, Q, VDD, VSS, notifier );
 input CLK, E, TE, VDD, VSS, notifier;
 output Q;
 

--- a/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_1.functional.pp.v
+++ b/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__inv_1( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__inv_1_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_12.functional.pp.v
+++ b/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_12.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__inv_12( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__inv_12_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_16.functional.pp.v
+++ b/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_16.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__inv_16( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__inv_16_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_2.functional.pp.v
+++ b/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__inv_2( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__inv_2_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_20.functional.pp.v
+++ b/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_20.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__inv_20( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__inv_20_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_3.functional.pp.v
+++ b/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_3.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__inv_3( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__inv_3_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_4.functional.pp.v
+++ b/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__inv_4( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__inv_4_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_8.functional.pp.v
+++ b/cells/inv/gf180mcu_fd_sc_mcu7t5v0__inv_8.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__inv_8( I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__inv_8_func( I, ZN, VDD, VSS );
 input I;
 inout VDD, VSS;
 output ZN;

--- a/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_1.functional.pp.v
+++ b/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__invz_1( EN, ZN, I, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__invz_1_func( EN, ZN, I, VDD, VSS );
 input EN, I;
 inout VDD, VSS;
 output ZN;

--- a/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_12.functional.pp.v
+++ b/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_12.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__invz_12( EN, I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__invz_12_func( EN, I, ZN, VDD, VSS );
 input EN, I;
 inout VDD, VSS;
 output ZN;

--- a/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_16.functional.pp.v
+++ b/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_16.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__invz_16( EN, I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__invz_16_func( EN, I, ZN, VDD, VSS );
 input EN, I;
 inout VDD, VSS;
 output ZN;

--- a/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_2.functional.pp.v
+++ b/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__invz_2( EN, ZN, I, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__invz_2_func( EN, ZN, I, VDD, VSS );
 input EN, I;
 inout VDD, VSS;
 output ZN;

--- a/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_3.functional.pp.v
+++ b/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_3.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__invz_3( EN, I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__invz_3_func( EN, I, ZN, VDD, VSS );
 input EN, I;
 inout VDD, VSS;
 output ZN;

--- a/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_4.functional.pp.v
+++ b/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__invz_4( EN, I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__invz_4_func( EN, I, ZN, VDD, VSS );
 input EN, I;
 inout VDD, VSS;
 output ZN;

--- a/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_8.functional.pp.v
+++ b/cells/invz/gf180mcu_fd_sc_mcu7t5v0__invz_8.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__invz_8( EN, I, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__invz_8_func( EN, I, ZN, VDD, VSS );
 input EN, I;
 inout VDD, VSS;
 output ZN;

--- a/cells/latq/gf180mcu_fd_sc_mcu7t5v0__latq_1.functional.pp.v
+++ b/cells/latq/gf180mcu_fd_sc_mcu7t5v0__latq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__latq_1( E, D, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__latq_1_func( E, D, Q, VDD, VSS, notifier );
 input D, E, VDD, VSS, notifier;
 output Q;
 

--- a/cells/latq/gf180mcu_fd_sc_mcu7t5v0__latq_2.functional.pp.v
+++ b/cells/latq/gf180mcu_fd_sc_mcu7t5v0__latq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__latq_2( E, D, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__latq_2_func( E, D, Q, VDD, VSS, notifier );
 input D, E, VDD, VSS, notifier;
 output Q;
 

--- a/cells/latq/gf180mcu_fd_sc_mcu7t5v0__latq_4.functional.pp.v
+++ b/cells/latq/gf180mcu_fd_sc_mcu7t5v0__latq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__latq_4( E, D, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__latq_4_func( E, D, Q, VDD, VSS, notifier );
 input D, E, VDD, VSS, notifier;
 output Q;
 

--- a/cells/latrnq/gf180mcu_fd_sc_mcu7t5v0__latrnq_1.functional.pp.v
+++ b/cells/latrnq/gf180mcu_fd_sc_mcu7t5v0__latrnq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__latrnq_1( E, D, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__latrnq_1_func( E, D, RN, Q, VDD, VSS, notifier );
 input D, E, RN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/latrnq/gf180mcu_fd_sc_mcu7t5v0__latrnq_2.functional.pp.v
+++ b/cells/latrnq/gf180mcu_fd_sc_mcu7t5v0__latrnq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__latrnq_2( E, D, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__latrnq_2_func( E, D, RN, Q, VDD, VSS, notifier );
 input D, E, RN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/latrnq/gf180mcu_fd_sc_mcu7t5v0__latrnq_4.functional.pp.v
+++ b/cells/latrnq/gf180mcu_fd_sc_mcu7t5v0__latrnq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__latrnq_4( E, D, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__latrnq_4_func( E, D, RN, Q, VDD, VSS, notifier );
 input D, E, RN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/latrsnq/gf180mcu_fd_sc_mcu7t5v0__latrsnq_1.functional.pp.v
+++ b/cells/latrsnq/gf180mcu_fd_sc_mcu7t5v0__latrsnq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__latrsnq_1( E, D, RN, SETN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__latrsnq_1_func( E, D, RN, SETN, Q, VDD, VSS, notifier );
 input D, E, RN, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/latrsnq/gf180mcu_fd_sc_mcu7t5v0__latrsnq_2.functional.pp.v
+++ b/cells/latrsnq/gf180mcu_fd_sc_mcu7t5v0__latrsnq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__latrsnq_2( E, D, RN, SETN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__latrsnq_2_func( E, D, RN, SETN, Q, VDD, VSS, notifier );
 input D, E, RN, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/latrsnq/gf180mcu_fd_sc_mcu7t5v0__latrsnq_4.functional.pp.v
+++ b/cells/latrsnq/gf180mcu_fd_sc_mcu7t5v0__latrsnq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__latrsnq_4( E, D, RN, SETN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__latrsnq_4_func( E, D, RN, SETN, Q, VDD, VSS, notifier );
 input D, E, RN, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/latsnq/gf180mcu_fd_sc_mcu7t5v0__latsnq_1.functional.pp.v
+++ b/cells/latsnq/gf180mcu_fd_sc_mcu7t5v0__latsnq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__latsnq_1( E, D, SETN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__latsnq_1_func( E, D, SETN, Q, VDD, VSS, notifier );
 input D, E, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/latsnq/gf180mcu_fd_sc_mcu7t5v0__latsnq_2.functional.pp.v
+++ b/cells/latsnq/gf180mcu_fd_sc_mcu7t5v0__latsnq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__latsnq_2( E, D, SETN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__latsnq_2_func( E, D, SETN, Q, VDD, VSS, notifier );
 input D, E, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/latsnq/gf180mcu_fd_sc_mcu7t5v0__latsnq_4.functional.pp.v
+++ b/cells/latsnq/gf180mcu_fd_sc_mcu7t5v0__latsnq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__latsnq_4( E, D, SETN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__latsnq_4_func( E, D, SETN, Q, VDD, VSS, notifier );
 input D, E, SETN, VDD, VSS, notifier;
 output Q;
 

--- a/cells/mux2/gf180mcu_fd_sc_mcu7t5v0__mux2_1.functional.pp.v
+++ b/cells/mux2/gf180mcu_fd_sc_mcu7t5v0__mux2_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__mux2_1( Z, I1, S, I0, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__mux2_1_func( Z, I1, S, I0, VDD, VSS );
 input I0, I1, S;
 inout VDD, VSS;
 output Z;

--- a/cells/mux2/gf180mcu_fd_sc_mcu7t5v0__mux2_2.functional.pp.v
+++ b/cells/mux2/gf180mcu_fd_sc_mcu7t5v0__mux2_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__mux2_2( Z, I1, S, I0, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__mux2_2_func( Z, I1, S, I0, VDD, VSS );
 input I0, I1, S;
 inout VDD, VSS;
 output Z;

--- a/cells/mux2/gf180mcu_fd_sc_mcu7t5v0__mux2_4.functional.pp.v
+++ b/cells/mux2/gf180mcu_fd_sc_mcu7t5v0__mux2_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__mux2_4( Z, I1, S, I0, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__mux2_4_func( Z, I1, S, I0, VDD, VSS );
 input I0, I1, S;
 inout VDD, VSS;
 output Z;

--- a/cells/mux4/gf180mcu_fd_sc_mcu7t5v0__mux4_1.functional.pp.v
+++ b/cells/mux4/gf180mcu_fd_sc_mcu7t5v0__mux4_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__mux4_1( I2, S0, I3, Z, S1, I1, I0, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__mux4_1_func( I2, S0, I3, Z, S1, I1, I0, VDD, VSS );
 input I0, I1, I2, I3, S0, S1;
 inout VDD, VSS;
 output Z;

--- a/cells/mux4/gf180mcu_fd_sc_mcu7t5v0__mux4_2.functional.pp.v
+++ b/cells/mux4/gf180mcu_fd_sc_mcu7t5v0__mux4_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__mux4_2( I2, S0, I3, Z, S1, I1, I0, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__mux4_2_func( I2, S0, I3, Z, S1, I1, I0, VDD, VSS );
 input I0, I1, I2, I3, S0, S1;
 inout VDD, VSS;
 output Z;

--- a/cells/mux4/gf180mcu_fd_sc_mcu7t5v0__mux4_4.functional.pp.v
+++ b/cells/mux4/gf180mcu_fd_sc_mcu7t5v0__mux4_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__mux4_4( I2, S0, I3, Z, S1, I1, I0, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__mux4_4_func( I2, S0, I3, Z, S1, I1, I0, VDD, VSS );
 input I0, I1, I2, I3, S0, S1;
 inout VDD, VSS;
 output Z;

--- a/cells/nand2/gf180mcu_fd_sc_mcu7t5v0__nand2_1.functional.pp.v
+++ b/cells/nand2/gf180mcu_fd_sc_mcu7t5v0__nand2_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nand2_1( A2, A1, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nand2_1_func( A2, A1, ZN, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output ZN;

--- a/cells/nand2/gf180mcu_fd_sc_mcu7t5v0__nand2_2.functional.pp.v
+++ b/cells/nand2/gf180mcu_fd_sc_mcu7t5v0__nand2_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nand2_2( A1, A2, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nand2_2_func( A1, A2, ZN, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output ZN;

--- a/cells/nand2/gf180mcu_fd_sc_mcu7t5v0__nand2_4.functional.pp.v
+++ b/cells/nand2/gf180mcu_fd_sc_mcu7t5v0__nand2_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nand2_4( A1, A2, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nand2_4_func( A1, A2, ZN, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output ZN;

--- a/cells/nand3/gf180mcu_fd_sc_mcu7t5v0__nand3_1.functional.pp.v
+++ b/cells/nand3/gf180mcu_fd_sc_mcu7t5v0__nand3_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nand3_1( A3, ZN, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nand3_1_func( A3, ZN, A2, A1, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output ZN;

--- a/cells/nand3/gf180mcu_fd_sc_mcu7t5v0__nand3_2.functional.pp.v
+++ b/cells/nand3/gf180mcu_fd_sc_mcu7t5v0__nand3_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nand3_2( ZN, A3, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nand3_2_func( ZN, A3, A2, A1, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output ZN;

--- a/cells/nand3/gf180mcu_fd_sc_mcu7t5v0__nand3_4.functional.pp.v
+++ b/cells/nand3/gf180mcu_fd_sc_mcu7t5v0__nand3_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nand3_4( A2, ZN, A3, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nand3_4_func( A2, ZN, A3, A1, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output ZN;

--- a/cells/nand4/gf180mcu_fd_sc_mcu7t5v0__nand4_1.functional.pp.v
+++ b/cells/nand4/gf180mcu_fd_sc_mcu7t5v0__nand4_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nand4_1( A4, ZN, A3, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nand4_1_func( A4, ZN, A3, A2, A1, VDD, VSS );
 input A1, A2, A3, A4;
 inout VDD, VSS;
 output ZN;

--- a/cells/nand4/gf180mcu_fd_sc_mcu7t5v0__nand4_2.functional.pp.v
+++ b/cells/nand4/gf180mcu_fd_sc_mcu7t5v0__nand4_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nand4_2( ZN, A3, A1, A4, A2, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nand4_2_func( ZN, A3, A1, A4, A2, VDD, VSS );
 input A1, A2, A3, A4;
 inout VDD, VSS;
 output ZN;

--- a/cells/nand4/gf180mcu_fd_sc_mcu7t5v0__nand4_4.functional.pp.v
+++ b/cells/nand4/gf180mcu_fd_sc_mcu7t5v0__nand4_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nand4_4( A3, ZN, A4, A1, A2, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nand4_4_func( A3, ZN, A4, A1, A2, VDD, VSS );
 input A1, A2, A3, A4;
 inout VDD, VSS;
 output ZN;

--- a/cells/nor2/gf180mcu_fd_sc_mcu7t5v0__nor2_1.functional.pp.v
+++ b/cells/nor2/gf180mcu_fd_sc_mcu7t5v0__nor2_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nor2_1( A2, ZN, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nor2_1_func( A2, ZN, A1, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output ZN;

--- a/cells/nor2/gf180mcu_fd_sc_mcu7t5v0__nor2_2.functional.pp.v
+++ b/cells/nor2/gf180mcu_fd_sc_mcu7t5v0__nor2_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nor2_2( A2, ZN, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nor2_2_func( A2, ZN, A1, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output ZN;

--- a/cells/nor2/gf180mcu_fd_sc_mcu7t5v0__nor2_4.functional.pp.v
+++ b/cells/nor2/gf180mcu_fd_sc_mcu7t5v0__nor2_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nor2_4( ZN, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nor2_4_func( ZN, A2, A1, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output ZN;

--- a/cells/nor3/gf180mcu_fd_sc_mcu7t5v0__nor3_1.functional.pp.v
+++ b/cells/nor3/gf180mcu_fd_sc_mcu7t5v0__nor3_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nor3_1( A3, ZN, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nor3_1_func( A3, ZN, A2, A1, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output ZN;

--- a/cells/nor3/gf180mcu_fd_sc_mcu7t5v0__nor3_2.functional.pp.v
+++ b/cells/nor3/gf180mcu_fd_sc_mcu7t5v0__nor3_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nor3_2( ZN, A3, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nor3_2_func( ZN, A3, A2, A1, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output ZN;

--- a/cells/nor3/gf180mcu_fd_sc_mcu7t5v0__nor3_4.functional.pp.v
+++ b/cells/nor3/gf180mcu_fd_sc_mcu7t5v0__nor3_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nor3_4( A2, ZN, A3, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nor3_4_func( A2, ZN, A3, A1, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output ZN;

--- a/cells/nor4/gf180mcu_fd_sc_mcu7t5v0__nor4_1.functional.pp.v
+++ b/cells/nor4/gf180mcu_fd_sc_mcu7t5v0__nor4_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nor4_1( A4, ZN, A3, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nor4_1_func( A4, ZN, A3, A2, A1, VDD, VSS );
 input A1, A2, A3, A4;
 inout VDD, VSS;
 output ZN;

--- a/cells/nor4/gf180mcu_fd_sc_mcu7t5v0__nor4_2.functional.pp.v
+++ b/cells/nor4/gf180mcu_fd_sc_mcu7t5v0__nor4_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nor4_2( A4, A3, ZN, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nor4_2_func( A4, A3, ZN, A2, A1, VDD, VSS );
 input A1, A2, A3, A4;
 inout VDD, VSS;
 output ZN;

--- a/cells/nor4/gf180mcu_fd_sc_mcu7t5v0__nor4_4.functional.pp.v
+++ b/cells/nor4/gf180mcu_fd_sc_mcu7t5v0__nor4_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__nor4_4( A4, A3, ZN, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__nor4_4_func( A4, A3, ZN, A2, A1, VDD, VSS );
 input A1, A2, A3, A4;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai21/gf180mcu_fd_sc_mcu7t5v0__oai21_1.functional.pp.v
+++ b/cells/oai21/gf180mcu_fd_sc_mcu7t5v0__oai21_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai21_1( A2, ZN, A1, B, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai21_1_func( A2, ZN, A1, B, VDD, VSS );
 input A1, A2, B;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai21/gf180mcu_fd_sc_mcu7t5v0__oai21_2.functional.pp.v
+++ b/cells/oai21/gf180mcu_fd_sc_mcu7t5v0__oai21_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai21_2( B, ZN, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai21_2_func( B, ZN, A2, A1, VDD, VSS );
 input A1, A2, B;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai21/gf180mcu_fd_sc_mcu7t5v0__oai21_4.functional.pp.v
+++ b/cells/oai21/gf180mcu_fd_sc_mcu7t5v0__oai21_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai21_4( A2, ZN, A1, B, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai21_4_func( A2, ZN, A1, B, VDD, VSS );
 input A1, A2, B;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai211/gf180mcu_fd_sc_mcu7t5v0__oai211_1.functional.pp.v
+++ b/cells/oai211/gf180mcu_fd_sc_mcu7t5v0__oai211_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai211_1( A2, ZN, A1, B, C, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai211_1_func( A2, ZN, A1, B, C, VDD, VSS );
 input A1, A2, B, C;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai211/gf180mcu_fd_sc_mcu7t5v0__oai211_2.functional.pp.v
+++ b/cells/oai211/gf180mcu_fd_sc_mcu7t5v0__oai211_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai211_2( A2, ZN, A1, B, C, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai211_2_func( A2, ZN, A1, B, C, VDD, VSS );
 input A1, A2, B, C;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai211/gf180mcu_fd_sc_mcu7t5v0__oai211_4.functional.pp.v
+++ b/cells/oai211/gf180mcu_fd_sc_mcu7t5v0__oai211_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai211_4( A2, ZN, A1, B, C, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai211_4_func( A2, ZN, A1, B, C, VDD, VSS );
 input A1, A2, B, C;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai22/gf180mcu_fd_sc_mcu7t5v0__oai22_1.functional.pp.v
+++ b/cells/oai22/gf180mcu_fd_sc_mcu7t5v0__oai22_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai22_1( B2, B1, ZN, A1, A2, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai22_1_func( B2, B1, ZN, A1, A2, VDD, VSS );
 input A1, A2, B1, B2;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai22/gf180mcu_fd_sc_mcu7t5v0__oai22_2.functional.pp.v
+++ b/cells/oai22/gf180mcu_fd_sc_mcu7t5v0__oai22_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai22_2( B2, B1, ZN, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai22_2_func( B2, B1, ZN, A2, A1, VDD, VSS );
 input A1, A2, B1, B2;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai22/gf180mcu_fd_sc_mcu7t5v0__oai22_4.functional.pp.v
+++ b/cells/oai22/gf180mcu_fd_sc_mcu7t5v0__oai22_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai22_4( B2, B1, ZN, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai22_4_func( B2, B1, ZN, A2, A1, VDD, VSS );
 input A1, A2, B1, B2;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai221/gf180mcu_fd_sc_mcu7t5v0__oai221_1.functional.pp.v
+++ b/cells/oai221/gf180mcu_fd_sc_mcu7t5v0__oai221_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai221_1( B2, B1, C, ZN, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai221_1_func( B2, B1, C, ZN, A2, A1, VDD, VSS );
 input A1, A2, B1, B2, C;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai221/gf180mcu_fd_sc_mcu7t5v0__oai221_2.functional.pp.v
+++ b/cells/oai221/gf180mcu_fd_sc_mcu7t5v0__oai221_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai221_2( B2, B1, ZN, C, A1, A2, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai221_2_func( B2, B1, ZN, C, A1, A2, VDD, VSS );
 input A1, A2, B1, B2, C;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai221/gf180mcu_fd_sc_mcu7t5v0__oai221_4.functional.pp.v
+++ b/cells/oai221/gf180mcu_fd_sc_mcu7t5v0__oai221_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai221_4( ZN, B1, B2, C, A1, A2, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai221_4_func( ZN, B1, B2, C, A1, A2, VDD, VSS );
 input A1, A2, B1, B2, C;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai222/gf180mcu_fd_sc_mcu7t5v0__oai222_1.functional.pp.v
+++ b/cells/oai222/gf180mcu_fd_sc_mcu7t5v0__oai222_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai222_1( C2, C1, B1, ZN, B2, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai222_1_func( C2, C1, B1, ZN, B2, A2, A1, VDD, VSS );
 input A1, A2, B1, B2, C1, C2;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai222/gf180mcu_fd_sc_mcu7t5v0__oai222_2.functional.pp.v
+++ b/cells/oai222/gf180mcu_fd_sc_mcu7t5v0__oai222_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai222_2( ZN, C1, C2, B1, B2, A1, A2, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai222_2_func( ZN, C1, C2, B1, B2, A1, A2, VDD, VSS );
 input A1, A2, B1, B2, C1, C2;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai222/gf180mcu_fd_sc_mcu7t5v0__oai222_4.functional.pp.v
+++ b/cells/oai222/gf180mcu_fd_sc_mcu7t5v0__oai222_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai222_4( C1, ZN, C2, B1, B2, A1, A2, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai222_4_func( C1, ZN, C2, B1, B2, A1, A2, VDD, VSS );
 input A1, A2, B1, B2, C1, C2;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai31/gf180mcu_fd_sc_mcu7t5v0__oai31_1.functional.pp.v
+++ b/cells/oai31/gf180mcu_fd_sc_mcu7t5v0__oai31_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai31_1( B, A1, ZN, A2, A3, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai31_1_func( B, A1, ZN, A2, A3, VDD, VSS );
 input A1, A2, A3, B;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai31/gf180mcu_fd_sc_mcu7t5v0__oai31_2.functional.pp.v
+++ b/cells/oai31/gf180mcu_fd_sc_mcu7t5v0__oai31_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai31_2( B, ZN, A3, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai31_2_func( B, ZN, A3, A2, A1, VDD, VSS );
 input A1, A2, A3, B;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai31/gf180mcu_fd_sc_mcu7t5v0__oai31_4.functional.pp.v
+++ b/cells/oai31/gf180mcu_fd_sc_mcu7t5v0__oai31_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai31_4( A3, ZN, A1, A2, B, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai31_4_func( A3, ZN, A1, A2, B, VDD, VSS );
 input A1, A2, A3, B;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai32/gf180mcu_fd_sc_mcu7t5v0__oai32_1.functional.pp.v
+++ b/cells/oai32/gf180mcu_fd_sc_mcu7t5v0__oai32_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai32_1( A3, A2, A1, ZN, B1, B2, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai32_1_func( A3, A2, A1, ZN, B1, B2, VDD, VSS );
 input A1, A2, A3, B1, B2;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai32/gf180mcu_fd_sc_mcu7t5v0__oai32_2.functional.pp.v
+++ b/cells/oai32/gf180mcu_fd_sc_mcu7t5v0__oai32_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai32_2( A3, A2, A1, ZN, B2, B1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai32_2_func( A3, A2, A1, ZN, B2, B1, VDD, VSS );
 input A1, A2, A3, B1, B2;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai32/gf180mcu_fd_sc_mcu7t5v0__oai32_4.functional.pp.v
+++ b/cells/oai32/gf180mcu_fd_sc_mcu7t5v0__oai32_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai32_4( A2, A3, A1, ZN, B2, B1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai32_4_func( A2, A3, A1, ZN, B2, B1, VDD, VSS );
 input A1, A2, A3, B1, B2;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai33/gf180mcu_fd_sc_mcu7t5v0__oai33_1.functional.pp.v
+++ b/cells/oai33/gf180mcu_fd_sc_mcu7t5v0__oai33_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai33_1( B3, B2, B1, ZN, A1, A2, A3, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai33_1_func( B3, B2, B1, ZN, A1, A2, A3, VDD, VSS );
 input A1, A2, A3, B1, B2, B3;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai33/gf180mcu_fd_sc_mcu7t5v0__oai33_2.functional.pp.v
+++ b/cells/oai33/gf180mcu_fd_sc_mcu7t5v0__oai33_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai33_2( B3, B2, ZN, B1, A3, A2, A1, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai33_2_func( B3, B2, ZN, B1, A3, A2, A1, VDD, VSS );
 input A1, A2, A3, B1, B2, B3;
 inout VDD, VSS;
 output ZN;

--- a/cells/oai33/gf180mcu_fd_sc_mcu7t5v0__oai33_4.functional.pp.v
+++ b/cells/oai33/gf180mcu_fd_sc_mcu7t5v0__oai33_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__oai33_4( B2, B3, B1, ZN, A1, A2, A3, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__oai33_4_func( B2, B3, B1, ZN, A1, A2, A3, VDD, VSS );
 input A1, A2, A3, B1, B2, B3;
 inout VDD, VSS;
 output ZN;

--- a/cells/or2/gf180mcu_fd_sc_mcu7t5v0__or2_1.functional.pp.v
+++ b/cells/or2/gf180mcu_fd_sc_mcu7t5v0__or2_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__or2_1( A1, A2, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__or2_1_func( A1, A2, Z, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output Z;

--- a/cells/or2/gf180mcu_fd_sc_mcu7t5v0__or2_2.functional.pp.v
+++ b/cells/or2/gf180mcu_fd_sc_mcu7t5v0__or2_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__or2_2( A1, A2, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__or2_2_func( A1, A2, Z, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output Z;

--- a/cells/or2/gf180mcu_fd_sc_mcu7t5v0__or2_4.functional.pp.v
+++ b/cells/or2/gf180mcu_fd_sc_mcu7t5v0__or2_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__or2_4( A2, A1, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__or2_4_func( A2, A1, Z, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output Z;

--- a/cells/or3/gf180mcu_fd_sc_mcu7t5v0__or3_1.functional.pp.v
+++ b/cells/or3/gf180mcu_fd_sc_mcu7t5v0__or3_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__or3_1( A1, A2, A3, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__or3_1_func( A1, A2, A3, Z, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output Z;

--- a/cells/or3/gf180mcu_fd_sc_mcu7t5v0__or3_2.functional.pp.v
+++ b/cells/or3/gf180mcu_fd_sc_mcu7t5v0__or3_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__or3_2( A1, A2, A3, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__or3_2_func( A1, A2, A3, Z, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output Z;

--- a/cells/or3/gf180mcu_fd_sc_mcu7t5v0__or3_4.functional.pp.v
+++ b/cells/or3/gf180mcu_fd_sc_mcu7t5v0__or3_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__or3_4( A3, A2, A1, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__or3_4_func( A3, A2, A1, Z, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output Z;

--- a/cells/or4/gf180mcu_fd_sc_mcu7t5v0__or4_1.functional.pp.v
+++ b/cells/or4/gf180mcu_fd_sc_mcu7t5v0__or4_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__or4_1( A1, A2, A3, A4, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__or4_1_func( A1, A2, A3, A4, Z, VDD, VSS );
 input A1, A2, A3, A4;
 inout VDD, VSS;
 output Z;

--- a/cells/or4/gf180mcu_fd_sc_mcu7t5v0__or4_2.functional.pp.v
+++ b/cells/or4/gf180mcu_fd_sc_mcu7t5v0__or4_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__or4_2( A1, A2, A3, A4, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__or4_2_func( A1, A2, A3, A4, Z, VDD, VSS );
 input A1, A2, A3, A4;
 inout VDD, VSS;
 output Z;

--- a/cells/or4/gf180mcu_fd_sc_mcu7t5v0__or4_4.functional.pp.v
+++ b/cells/or4/gf180mcu_fd_sc_mcu7t5v0__or4_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__or4_4( A4, A3, A2, A1, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__or4_4_func( A4, A3, A2, A1, Z, VDD, VSS );
 input A1, A2, A3, A4;
 inout VDD, VSS;
 output Z;

--- a/cells/sdffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_1.functional.pp.v
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__sdffq_1( SE, SI, D, CLK, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__sdffq_1_func( SE, SI, D, CLK, Q, VDD, VSS, notifier );
 input CLK, D, SE, SI, VDD, VSS, notifier;
 output Q;
 

--- a/cells/sdffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_2.functional.pp.v
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__sdffq_2( SE, SI, D, CLK, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__sdffq_2_func( SE, SI, D, CLK, Q, VDD, VSS, notifier );
 input CLK, D, SE, SI, VDD, VSS, notifier;
 output Q;
 

--- a/cells/sdffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_4.functional.pp.v
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu7t5v0__sdffq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__sdffq_4( SE, SI, D, CLK, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__sdffq_4_func( SE, SI, D, CLK, Q, VDD, VSS, notifier );
 input CLK, D, SE, SI, VDD, VSS, notifier;
 output Q;
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_1.functional.pp.v
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__sdffrnq_1( SE, SI, D, CLK, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__sdffrnq_1_func( SE, SI, D, CLK, RN, Q, VDD, VSS, notifier );
 input CLK, D, RN, SE, SI, VDD, VSS, notifier;
 output Q;
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_2.functional.pp.v
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__sdffrnq_2( SE, SI, D, CLK, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__sdffrnq_2_func( SE, SI, D, CLK, RN, Q, VDD, VSS, notifier );
 input CLK, D, RN, SE, SI, VDD, VSS, notifier;
 output Q;
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_4.functional.pp.v
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu7t5v0__sdffrnq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__sdffrnq_4( SE, SI, D, CLK, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__sdffrnq_4_func( SE, SI, D, CLK, RN, Q, VDD, VSS, notifier );
 input CLK, D, RN, SE, SI, VDD, VSS, notifier;
 output Q;
 

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_1.functional.pp.v
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_1( SE, SI, D, CLK, SETN, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_1_func( SE, SI, D, CLK, SETN, RN, Q, VDD, VSS, notifier );
 input CLK, D, RN, SE, SETN, SI, VDD, VSS, notifier;
 output Q;
 

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_2.functional.pp.v
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_2( SE, SI, D, CLK, SETN, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_2_func( SE, SI, D, CLK, SETN, RN, Q, VDD, VSS, notifier );
 input CLK, D, RN, SE, SETN, SI, VDD, VSS, notifier;
 output Q;
 

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_4.functional.pp.v
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_4( SE, SI, D, CLK, SETN, RN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__sdffrsnq_4_func( SE, SI, D, CLK, SETN, RN, Q, VDD, VSS, notifier );
 input CLK, D, RN, SE, SETN, SI, VDD, VSS, notifier;
 output Q;
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_1.functional.pp.v
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__sdffsnq_1( SE, SI, D, CLK, SETN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__sdffsnq_1_func( SE, SI, D, CLK, SETN, Q, VDD, VSS, notifier );
 input CLK, D, SE, SETN, SI, VDD, VSS, notifier;
 output Q;
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_2.functional.pp.v
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__sdffsnq_2( SE, SI, D, CLK, SETN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__sdffsnq_2_func( SE, SI, D, CLK, SETN, Q, VDD, VSS, notifier );
 input CLK, D, SE, SETN, SI, VDD, VSS, notifier;
 output Q;
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_4.functional.pp.v
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu7t5v0__sdffsnq_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__sdffsnq_4( SE, SI, D, CLK, SETN, Q, VDD, VSS, notifier );
+module gf180mcu_fd_sc_mcu7t5v0__sdffsnq_4_func( SE, SI, D, CLK, SETN, Q, VDD, VSS, notifier );
 input CLK, D, SE, SETN, SI, VDD, VSS, notifier;
 output Q;
 

--- a/cells/tieh/gf180mcu_fd_sc_mcu7t5v0__tieh.functional.pp.v
+++ b/cells/tieh/gf180mcu_fd_sc_mcu7t5v0__tieh.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__tieh( Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__tieh_func( Z, VDD, VSS );
 inout VDD, VSS;
 output Z;
 

--- a/cells/tiel/gf180mcu_fd_sc_mcu7t5v0__tiel.functional.pp.v
+++ b/cells/tiel/gf180mcu_fd_sc_mcu7t5v0__tiel.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__tiel( ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__tiel_func( ZN, VDD, VSS );
 inout VDD, VSS;
 output ZN;
 

--- a/cells/xnor2/gf180mcu_fd_sc_mcu7t5v0__xnor2_1.functional.pp.v
+++ b/cells/xnor2/gf180mcu_fd_sc_mcu7t5v0__xnor2_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__xnor2_1( A2, A1, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__xnor2_1_func( A2, A1, ZN, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output ZN;

--- a/cells/xnor2/gf180mcu_fd_sc_mcu7t5v0__xnor2_2.functional.pp.v
+++ b/cells/xnor2/gf180mcu_fd_sc_mcu7t5v0__xnor2_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__xnor2_2( A2, A1, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__xnor2_2_func( A2, A1, ZN, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output ZN;

--- a/cells/xnor2/gf180mcu_fd_sc_mcu7t5v0__xnor2_4.functional.pp.v
+++ b/cells/xnor2/gf180mcu_fd_sc_mcu7t5v0__xnor2_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__xnor2_4( A2, A1, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__xnor2_4_func( A2, A1, ZN, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output ZN;

--- a/cells/xnor3/gf180mcu_fd_sc_mcu7t5v0__xnor3_1.functional.pp.v
+++ b/cells/xnor3/gf180mcu_fd_sc_mcu7t5v0__xnor3_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__xnor3_1( A2, A1, A3, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__xnor3_1_func( A2, A1, A3, ZN, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output ZN;

--- a/cells/xnor3/gf180mcu_fd_sc_mcu7t5v0__xnor3_2.functional.pp.v
+++ b/cells/xnor3/gf180mcu_fd_sc_mcu7t5v0__xnor3_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__xnor3_2( A2, A1, A3, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__xnor3_2_func( A2, A1, A3, ZN, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output ZN;

--- a/cells/xnor3/gf180mcu_fd_sc_mcu7t5v0__xnor3_4.functional.pp.v
+++ b/cells/xnor3/gf180mcu_fd_sc_mcu7t5v0__xnor3_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__xnor3_4( A2, A1, A3, ZN, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__xnor3_4_func( A2, A1, A3, ZN, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output ZN;

--- a/cells/xor2/gf180mcu_fd_sc_mcu7t5v0__xor2_1.functional.pp.v
+++ b/cells/xor2/gf180mcu_fd_sc_mcu7t5v0__xor2_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__xor2_1( A2, A1, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__xor2_1_func( A2, A1, Z, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output Z;

--- a/cells/xor2/gf180mcu_fd_sc_mcu7t5v0__xor2_2.functional.pp.v
+++ b/cells/xor2/gf180mcu_fd_sc_mcu7t5v0__xor2_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__xor2_2( A2, A1, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__xor2_2_func( A2, A1, Z, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output Z;

--- a/cells/xor2/gf180mcu_fd_sc_mcu7t5v0__xor2_4.functional.pp.v
+++ b/cells/xor2/gf180mcu_fd_sc_mcu7t5v0__xor2_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__xor2_4( A2, A1, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__xor2_4_func( A2, A1, Z, VDD, VSS );
 input A1, A2;
 inout VDD, VSS;
 output Z;

--- a/cells/xor3/gf180mcu_fd_sc_mcu7t5v0__xor3_1.functional.pp.v
+++ b/cells/xor3/gf180mcu_fd_sc_mcu7t5v0__xor3_1.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__xor3_1( A2, A1, A3, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__xor3_1_func( A2, A1, A3, Z, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output Z;

--- a/cells/xor3/gf180mcu_fd_sc_mcu7t5v0__xor3_2.functional.pp.v
+++ b/cells/xor3/gf180mcu_fd_sc_mcu7t5v0__xor3_2.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__xor3_2( A2, A1, A3, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__xor3_2_func( A2, A1, A3, Z, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output Z;

--- a/cells/xor3/gf180mcu_fd_sc_mcu7t5v0__xor3_4.functional.pp.v
+++ b/cells/xor3/gf180mcu_fd_sc_mcu7t5v0__xor3_4.functional.pp.v
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gf180mcu_fd_sc_mcu7t5v0__xor3_4( A2, A1, A3, Z, VDD, VSS );
+module gf180mcu_fd_sc_mcu7t5v0__xor3_4_func( A2, A1, A3, Z, VDD, VSS );
 input A1, A2, A3;
 inout VDD, VSS;
 output Z;


### PR DESCRIPTION
Workaround #24

Using:
```
sed -i -e 's/module \(.*\)(/module \1_func(/' cells/*/*.functional.pp.v
```

Regenerated the library file with `open_pdks` https://github.com/RTimothyEdwards/open_pdks/blob/master/common/foundry_install.py:
```
python3 common/foundry_install.py -source ~/src/github.com/google/globalfoundries-pdk-libs-gf180mcu_fd_sc_mcu7t5v0/ \
                                  -target /tmp/out \
                                  -library digital gf180mcu_fd_sc_mcu7t5v0 \
                                  -verilog 'cells/*/*.v' compile-only
```
for testing purpose: [gf180mcu_fd_sc_mcu7t5v0.zip](https://github.com/google/globalfoundries-pdk-libs-gf180mcu_fd_sc_mcu7t5v0/files/10101953/gf180mcu_fd_sc_mcu7t5v0.zip)
